### PR TITLE
ref #196 A subclass should work in place of an annotated superclass.

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/translate/Translators.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/Translators.java
@@ -6,8 +6,10 @@ import com.googlecode.objectify.impl.Path;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 
@@ -127,6 +129,34 @@ public class Translators
 	 */
 	public <P> Translator<P, PropertyContainer> getRoot(Class<P> clazz) {
 		return get(new TypeKey(clazz), new CreateContext(fact), Path.root());
+	}
+	
+	/**
+	 * Lists every TypeKey where this class could be assigned.
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public <P> List<TypeKey> listEveryTypeKeyForAncestors(Class<P> clazz) {
+		List<TypeKey> types = new ArrayList<>();
+		for (TypeKey type : translators.keySet()) {
+			if (type.getTypeAsClass().isAssignableFrom(clazz)) {
+				types.add(type);
+			}
+		}
+		return types;
+	}
+	
+	/**
+	 * Lists a class registered subclasses.
+	 */
+	@SuppressWarnings({ "rawtypes" })
+	public <P> Set<Class<?>> listRegisteredSubclasses(Class<P> clazz) {
+		Set<Class<?>> subclasses = new HashSet<>();
+		for (TypeKey type : translators.keySet()) {
+			if (clazz != type.getTypeAsClass() && clazz.isAssignableFrom(type.getTypeAsClass())) {
+				subclasses.add(type.getTypeAsClass());
+			}
+		}
+		return subclasses;
 	}
 
 	/**

--- a/src/test/java/com/googlecode/objectify/test/MapifyTests.java
+++ b/src/test/java/com/googlecode/objectify/test/MapifyTests.java
@@ -6,9 +6,11 @@ import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Load;
 import com.googlecode.objectify.annotation.Mapify;
+import com.googlecode.objectify.annotation.Subclass;
 import com.googlecode.objectify.mapper.Mapper;
 import com.googlecode.objectify.test.entity.Trivial;
 import com.googlecode.objectify.test.util.TestBase;
+
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -44,6 +46,17 @@ public class MapifyTests extends TestBase
 			return "Thing(name=" + name + ", weight=" + weight + ")";
 		}
 	}
+	
+	@Subclass
+	public static class ThingSubclass extends Thing {
+		
+		public ThingSubclass() { }
+		
+		public ThingSubclass(String name, Long weight) {
+			super(name, weight);
+		}
+		
+	}
 
 	public static class ThingMapper implements Mapper<Long, Thing> {
 		@Override
@@ -71,6 +84,24 @@ public class MapifyTests extends TestBase
 		Thing thing1 = new Thing("bar", 456L);
 		hasMap.things.put(thing1.weight, thing1);
 
+		checkTestMapify(hasMap);
+	}
+
+	@Test
+	public void testMapifyPolymorphic() throws Exception {
+		fact().register(HasMapify.class);
+		fact().register(ThingSubclass.class);
+		
+		HasMapify hasMap = new HasMapify();
+		Thing thing0 = new ThingSubclass("foo", 123L);
+		hasMap.things.put(thing0.weight, thing0);
+		Thing thing1 = new ThingSubclass("bar", 456L);
+		hasMap.things.put(thing1.weight, thing1);
+		
+		checkTestMapify(hasMap);
+	}
+
+	private void checkTestMapify(HasMapify hasMap) {
 		HasMapify fetched = ofy().saveClearLoad(hasMap);
 
 		assert hasMap.things.equals(fetched.things);

--- a/src/test/java/com/googlecode/objectify/test/PolymorphicEmbeddedRegisterTests.java
+++ b/src/test/java/com/googlecode/objectify/test/PolymorphicEmbeddedRegisterTests.java
@@ -1,0 +1,213 @@
+package com.googlecode.objectify.test;
+
+import static com.googlecode.objectify.test.util.TestObjectifyService.fact;
+import static com.googlecode.objectify.test.util.TestObjectifyService.ofy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.Mapify;
+import com.googlecode.objectify.annotation.Stringify;
+import com.googlecode.objectify.annotation.Subclass;
+import com.googlecode.objectify.mapper.Mapper;
+import com.googlecode.objectify.stringifier.Stringifier;
+import com.googlecode.objectify.test.util.TestBase;
+
+/**
+ * Check if the polymorphic embedded subclasses cause any exceptions depending on the usage place and the registration order.
+ * See #196
+ * 
+ * @author Tamas Tozser <ttozser@gmail.com>
+ */
+public class PolymorphicEmbeddedRegisterTests extends TestBase {
+	
+	@Entity
+	static class EnityWithField {
+		@Id
+		long id = 1;
+		EmbeddedSuperclass field;
+	}
+	
+	@Entity
+	static class EnityWithList {
+		@Id
+		long id = 1;
+		List<EmbeddedSuperclass> fields;
+	}
+	
+	@Entity
+	static class EnityWithMap {
+		@Id
+		long id = 1;
+		Map<String, EmbeddedSuperclass> map;
+	}
+	
+	@Entity
+	static class EnityWithStringify {
+		@Id
+		long id = 1;
+		@Stringify(SuperEmbeddedClassStringifier.class)
+		Map<EmbeddedSuperclass, EmbeddedSuperclass> map;
+		
+		static class SuperEmbeddedClassStringifier implements Stringifier<EmbeddedSuperclass> {
+			@Override
+			public String toString(EmbeddedSuperclass obj) {
+				return obj.id;
+			}
+			
+			@Override
+			public EmbeddedSuperclass fromString(String str) {
+				return new EmbeddedSuperclass();
+			}
+		}
+	}
+	
+	@Entity
+	static class EnityWithMapify {
+		@Id
+		long id = 1;
+		@Mapify(SuperClassMapper.class)
+		Map<String, EmbeddedSuperclass> map;
+		
+		static class SuperClassMapper implements Mapper<String, EmbeddedSuperclass> {
+			@Override
+			public String getKey(EmbeddedSuperclass superClass) {
+				return superClass.id;
+			}
+		}
+	}
+	
+	static class EmbeddedSuperclass {
+		String id = "foo";
+	}
+	
+	@Subclass
+	static class EmbeddedSubclass extends EmbeddedSuperclass {
+	}
+	
+	@Subclass
+	static class EmbeddedSubSubclass extends EmbeddedSubclass {
+	}
+	
+	@Test
+	public void testPolymorphicField() {
+		fact().register(EnityWithField.class);
+		fact().register(EmbeddedSubSubclass.class);
+		
+		checkField();
+	}
+	
+	@Test
+	public void testPolymorphicFieldReverseRegistration() {
+		fact().register(EmbeddedSubSubclass.class);
+		fact().register(EnityWithField.class);
+		
+		checkField();
+	}
+	
+	private void checkField() {
+		EnityWithField enityWithField = new EnityWithField();
+		enityWithField.field = new EmbeddedSubSubclass();
+		
+		ofy().saveClearLoad(enityWithField);
+	}
+	
+	@Test
+	public void testPolymorphicList() {
+		fact().register(EnityWithList.class);
+		fact().register(EmbeddedSubSubclass.class);
+		
+		checkList();
+	}
+	
+	@Test
+	public void testPolymorphicListReverseRegistration() {
+		fact().register(EmbeddedSubSubclass.class);
+		fact().register(EnityWithList.class);
+		
+		checkList();
+	}
+	
+	private void checkList() {
+		EnityWithList enityWithlist = new EnityWithList();
+		enityWithlist.fields = Lists.<EmbeddedSuperclass> newArrayList(new EmbeddedSubSubclass());
+		
+		ofy().saveClearLoad(enityWithlist);
+	}
+	
+	@Test
+	public void testPolymorphicMap() {
+		fact().register(EnityWithMap.class);
+		fact().register(EmbeddedSubSubclass.class);
+		
+		checkMap();
+	}
+	
+	@Test
+	public void testPolymorphicMapReverseRegistration() {
+		fact().register(EmbeddedSubSubclass.class);
+		fact().register(EnityWithMap.class);
+		
+		checkMap();
+	}
+	
+	private void checkMap() {
+		EnityWithMap enityWithMap = new EnityWithMap();
+		enityWithMap.map = ImmutableMap.<String, EmbeddedSuperclass>of("foo", new EmbeddedSubSubclass());
+		
+		ofy().saveClearLoad(enityWithMap);
+	}
+
+	@Test
+	public void testPolymorphicStringify() {
+		fact().register(EnityWithStringify.class);
+		fact().register(EmbeddedSubSubclass.class);
+		
+		checkStringify();
+	}
+	
+	@Test
+	public void testPolymorphicStringifyReverseRegistration() {
+		fact().register(EmbeddedSubSubclass.class);
+		fact().register(EnityWithStringify.class);
+		
+		checkStringify();
+	}
+	
+	private void checkStringify() {
+		EnityWithStringify enityWithStringify = new EnityWithStringify();
+		enityWithStringify.map = ImmutableMap.<EmbeddedSuperclass, EmbeddedSuperclass>of(new EmbeddedSubSubclass(), new EmbeddedSubSubclass());
+		
+		ofy().saveClearLoad(enityWithStringify);
+	}
+
+	@Test
+	public void testPolymorphicMapify() {
+		fact().register(EnityWithMapify.class);
+		fact().register(EmbeddedSubSubclass.class);
+		
+		checkMapify();
+	}
+	
+	@Test
+	public void testPolymorphicMapifyReverseRegistration() {
+		fact().register(EmbeddedSubSubclass.class);
+		fact().register(EnityWithMapify.class);
+		
+		checkMapify();
+	}
+	
+	private void checkMapify() {
+		EnityWithMapify enityWithMapify = new EnityWithMapify();
+		enityWithMapify.map = ImmutableMap.<String, EmbeddedSuperclass>of("foo", new EmbeddedSubSubclass());
+		
+		ofy().saveClearLoad(enityWithMapify);
+	}
+	
+}


### PR DESCRIPTION
Currently when you register a subclass you register it with an annotationless TypeKey.
If you try to use this subclass in place of an annotated superclass (@Mapify, @Stringify, @Unindex, @Index) you get an exception.

This pull request makes sure when you register a subclass you register it for  every TypeKey of the superclasses and when you add a new typekey for a class then you register every subclass to those annotations too.

I needed the newly created translator in the translators map before the Translators.get() could put it in there so I add it directly in the ClassTranslatorFactory. I don't know the project well enough to find a better solution.
