### PR TITLE
Modify Key class constructor to protected.

### DIFF
--- a/src/main/java/com/googlecode/objectify/Key.java
+++ b/src/main/java/com/googlecode/objectify/Key.java
@@ -69,25 +69,25 @@ public class Key<T> implements Serializable, Comparable<Key<?>>
 	transient protected Key<?> parent;
 
 	/** For GWT serialization */
-	private Key() {}
+	protected Key() {}
 
 	/** Wrap a raw Key */
-	private Key(com.google.appengine.api.datastore.Key raw) {
+	protected Key(com.google.appengine.api.datastore.Key raw) {
 		this.raw = raw;
 	}
 
 	/** Create a key with a long id */
-	private Key(Class<? extends T> kindClass, long id) {
+	protected Key(Class<? extends T> kindClass, long id) {
 		this(null, kindClass, id);
 	}
 
 	/** Create a key with a String name */
-	private Key(Class<? extends T> kindClass, String name) {
+	protected Key(Class<? extends T> kindClass, String name) {
 		this(null, kindClass, name);
 	}
 
 	/** Create a key with a parent and a long id */
-	private Key(Key<?> parent, Class<? extends T> kindClass, long id) {
+	protected Key(Key<?> parent, Class<? extends T> kindClass, long id) {
 		this.raw = KeyFactory.createKey(key(parent), getKind(kindClass), id);
 		this.parent = parent;
 	}
@@ -102,7 +102,7 @@ public class Key<T> implements Serializable, Comparable<Key<?>>
 	 * Reconstitute a Key from a web safe string.  This can be generated with getString()/toWebSafeString()
 	 * or KeyFactory.stringToKey().
 	 */
-	private Key(String webSafe) {
+	protected Key(String webSafe) {
 		this(KeyFactory.stringToKey(webSafe));
 	}
 


### PR DESCRIPTION
I'm currently creating annotation processor project for Objectify.
With this project, many convenient class source codes for Objectify will automatically generated by annotation processor.

One of generated class will be key class for specific entity.
**To to this, modifier of constructors of `Key` class should be modified to at least protected.**

Let me give example about key class for specific entity:

	@Entity
	public class Article {
	    @Id
	     private long id;
	     ...
	}

Will generate specific key class like:

	public ArticleKey extends Key<Article> {
	    ...
	}

I think this kind of specific key class makes easier to use Objectify library.

	// original
	Key<Article> articleKey = Key.create(Article.class, articleId);
        Key<Comment> commentKey = Key.create(articleKey, Comment.class, commentId)

	// with objectify-apt library
	ArticleKey  articleKey = ArticleKey.newKey(articleId); 
	CommentKey commentKey = articleKey.newCommentKey(commentId);
	LoadResult<Comment> key = ofy().load().key(commentKey);

There are several benefits such as...

- (Slightly) Shorter code.
- Easier auto-completion for creating key class.
- Parent-Child relationship between Entity can be strictly on compile time
- And so on...

So, please accept this pull-request!