### PR TITLE
Post Transaction Commit Listeners

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/TransactionImpl.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactionImpl.java
@@ -24,6 +24,9 @@ public class TransactionImpl extends TransactionWrapper {
 	 */
 	private List<Result<?>> enlisted = new ArrayList<>();
 
+
+	private List<Runnable> listeners = new ArrayList<>();
+
 	/** */
 	public TransactionImpl(Transaction raw, TransactorYes<?> transactor) {
 		super(raw);
@@ -35,6 +38,13 @@ public class TransactionImpl extends TransactionWrapper {
 	 */
 	public void enlist(Result<?> result) {
 		enlisted.add(result);
+	}
+
+	/**
+	 * Add a listener to be called after the transaction commits.
+	 */
+	public void listenForCommit(Runnable listener) {
+		listeners.add(listener);
 	}
 
 	/* (non-Javadoc)
@@ -65,6 +75,9 @@ public class TransactionImpl extends TransactionWrapper {
 			@Override
 			protected Void wrap(Void nothing) throws Exception {
 				transactor.committed();
+				for (Runnable listener : listeners) {
+					listener.run();
+				}
 				return nothing;
 			}
 		};


### PR DESCRIPTION
This pull request adds post transaction commit listeners to objectify.  The motivating use case for this change is pseudo-transactional task enqueue - by moving task enqueues into a post-transaction call back, you can avoid the task running before the datastore is updated while also overcoming the limit on the number of tasks that can be included in a transaction.

To add a listener call listenForCommit(Runnable listener) on the current transaction.  Any number of listeners can be added.