### PR TITLE
Post Transaction Commit Listeners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>com.googlecode.objectify</groupId>
 	<artifactId>objectify</artifactId>
-	<version>MANUAL</version>
+	<version>5.1.9-SNAPSHOT</version>
 
 	<name>Objectify App Engine</name>
 	<description>The simplest convenient interface to the Google App Engine datastore</description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>com.googlecode.objectify</groupId>
 	<artifactId>objectify</artifactId>
-	<version>5.1.9-SNAPSHOT</version>
+	<version>MANUAL</version>
 
 	<name>Objectify App Engine</name>
 	<description>The simplest convenient interface to the Google App Engine datastore</description>

--- a/src/main/java/com/googlecode/objectify/impl/TransactionImpl.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactionImpl.java
@@ -24,6 +24,9 @@ public class TransactionImpl extends TransactionWrapper {
 	 */
 	private List<Result<?>> enlisted = new ArrayList<>();
 
+
+	private List<Runnable> listeners = new ArrayList<>();
+
 	/** */
 	public TransactionImpl(Transaction raw, TransactorYes<?> transactor) {
 		super(raw);
@@ -35,6 +38,13 @@ public class TransactionImpl extends TransactionWrapper {
 	 */
 	public void enlist(Result<?> result) {
 		enlisted.add(result);
+	}
+
+	/**
+	 * Add a listener to be called after the transaction commits.
+	 */
+	public void listenForCommit(Runnable listener) {
+		listeners.add(listener);
 	}
 
 	/* (non-Javadoc)
@@ -65,6 +75,9 @@ public class TransactionImpl extends TransactionWrapper {
 			@Override
 			protected Void wrap(Void nothing) throws Exception {
 				transactor.committed();
+				for (Runnable listener : listeners) {
+					listener.run();
+				}
 				return nothing;
 			}
 		};

--- a/src/main/java/com/googlecode/objectify/impl/TransactionImpl.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactionImpl.java
@@ -47,6 +47,12 @@ public class TransactionImpl extends TransactionWrapper {
 		listeners.add(listener);
 	}
 
+	public void runCommitListeners() {
+		for (Runnable listener : listeners) {
+			listener.run();
+		}
+	}
+
 	/* (non-Javadoc)
 	 * @see com.googlecode.objectify.util.cmd.TransactionWrapper#commit()
 	 */
@@ -75,9 +81,6 @@ public class TransactionImpl extends TransactionWrapper {
 			@Override
 			protected Void wrap(Void nothing) throws Exception {
 				transactor.committed();
-				for (Runnable listener : listeners) {
-					listener.run();
-				}
 				return nothing;
 			}
 		};

--- a/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
@@ -124,6 +124,7 @@ public class TransactorNo<O extends Objectify> extends Transactor<O>
 		}
 		finally
 		{
+			boolean committedSuccessfully = false;
 			if (txnOfy.getTransaction().isActive()) {
 				try {
 					txnOfy.getTransaction().rollback();
@@ -131,8 +132,15 @@ public class TransactorNo<O extends Objectify> extends Transactor<O>
 					log.log(Level.SEVERE, "Rollback failed, suppressing error", ex);
 				}
 			}
+			else {
+				committedSuccessfully = true;
+			}
 
 			ObjectifyService.pop();
+
+			if (committedSuccessfully) {
+				txnOfy.getTransaction().runCommitListeners();
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request adds post transaction commit listeners to objectify. The motivating use case for this change is pseudo-transactional task enqueue - by moving task enqueues into a post-transaction call back, you can avoid the task running before the datastore is updated while also overcoming the limit on the number of tasks that can be included in a transaction.

To add a listener call listenForCommit(Runnable listener) on the current transaction. Any number of listeners can be added.