### PR TITLE
Fixes an issue that transaction commit listeners get called multiple times if a transaction is retried.

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
@@ -116,24 +116,22 @@ public class TransactorNo<O extends Objectify> extends Transactor<O>
 		ObjectifyImpl<O> txnOfy = startTransaction(parent);
 		ObjectifyService.push(txnOfy);
 
+		boolean committedSuccessfully = false;
 		try {
 			R result = work.run();
 			txnOfy.flush();
 			txnOfy.getTransaction().commit();
+			committedSuccessfully = true;
 			return result;
 		}
 		finally
 		{
-			boolean committedSuccessfully = false;
 			if (txnOfy.getTransaction().isActive()) {
 				try {
 					txnOfy.getTransaction().rollback();
 				} catch (RuntimeException ex) {
 					log.log(Level.SEVERE, "Rollback failed, suppressing error", ex);
 				}
-			}
-			else {
-				committedSuccessfully = true;
 			}
 
 			ObjectifyService.pop();

--- a/src/test/java/com/googlecode/objectify/test/TransactionTests.java
+++ b/src/test/java/com/googlecode/objectify/test/TransactionTests.java
@@ -337,6 +337,108 @@ public class TransactionTests extends TestBase
 		assert !listener.hasRun();
 	}
 
+	public static class CommitCountListener implements Runnable {
+		private int commitCount = 0;
+
+		@Override
+		public void run() {
+			commitCount++;
+		}
+
+		public int getCommitCount() {
+			return commitCount;
+		}
+	}
+
+	/**
+	 */
+	@Test
+	public void listenerIsOnlyCalledOnceIfTransactionRetries() {
+		final CommitCountListener listener = new CommitCountListener();
+		final Counter counter = new Counter();
+
+		ofy().transactNew(3, new VoidWork() {
+			@Override
+			public void vrun() {
+				counter.counter++;
+				TransactionImpl txn = ofy().getTransaction();
+				txn.listenForCommit(listener);
+
+				if (counter.counter < 3) {
+					throw new ConcurrentModificationException();
+				}
+			}
+		});
+
+		assert counter.counter == 3;
+		assert listener.getCommitCount() == 1;
+	}
+
+	/**
+	 */
+	@Test
+	public void testListenerNotCalledWithOrganicConcurrencyFailure() throws Exception {
+		fact().register(Trivial.class);
+
+		Trivial triv = new Trivial("foo", 5);
+		final Key<Trivial> tk = ofy().save().entity(triv).now();
+		final SimpleCommitListener listener = new SimpleCommitListener();
+
+		try {
+			ofy().transactNew(1, new VoidWork() {
+				@Override
+				public void vrun() {
+					TransactionImpl txn = ofy().getTransaction();
+					txn.listenForCommit(listener);
+
+					Trivial triv1 = ofy().transactionless().load().key(tk).now();
+					Trivial triv2 = ofy().load().key(tk).now();
+
+
+					ofy().transactionless().save().entity(triv1).now();
+					ofy().save().entity(triv2).now();
+				}
+			});
+			assert false;	// must throw exception
+		}
+		catch (ConcurrentModificationException ex) {}
+
+		assert !listener.hasRun();
+	}
+
+	/**
+	 */
+	@Test
+	public void listenerIsOnlyCalledOnceIfTransactionRetriesFromOrganicConcurrencyFailure() {
+		fact().register(Trivial.class);
+
+		Trivial triv = new Trivial("foo", 5);
+		final Key<Trivial> tk = ofy().save().entity(triv).now();
+		final CommitCountListener listener = new CommitCountListener();
+		final Counter counter = new Counter();
+
+		ofy().transactNew(3, new VoidWork() {
+			@Override
+			public void vrun() {
+				counter.counter++;
+				TransactionImpl txn = ofy().getTransaction();
+				txn.listenForCommit(listener);
+
+				Trivial triv1 = ofy().transactionless().load().key(tk).now();
+				Trivial triv2 = ofy().load().key(tk).now();
+
+
+				if (counter.counter < 3) {
+					ofy().transactionless().save().entity(triv1).now();
+				}
+				ofy().save().entity(triv2).now();
+			}
+		});
+
+		assert counter.counter == 3;
+		assert listener.getCommitCount() == 1;
+	}
+
 	/**
 	 */
 	@Test


### PR DESCRIPTION
The current implementation of post-transaction listeners is incorrect because it is possible for them to be called multiple times if a transaction is retried.  This is because thrown exception affects the state of a transaction differently depending on whether it is raised before the transaction is committed or while the transaction is being committed.  If the exception is raised while the transaction is being committed, the low-level transaction object will report it is no longer active.  As such, we can't use the .isActive() method on a transaction to determine if the transaction was committed.  Thus, to ensure that the transaction listeners only get called if the transaction was successfully applied, we have to set the boolean flag committedSuccessfully inside the try block of transactOnce(), where it will only be run if no exceptions are raised from running the transactional Work or from committing the transaction.