### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/googlecode/objectify/cache/CachingDatastoreServiceFactory.java
+++ b/src/main/java/com/googlecode/objectify/cache/CachingDatastoreServiceFactory.java
@@ -19,7 +19,10 @@ import com.googlecode.objectify.ObjectifyFactory;
 public class CachingDatastoreServiceFactory
 {
 	private static String defaultMemcacheNamespace = ObjectifyFactory.MEMCACHE_NAMESPACE;
-	
+
+	private CachingDatastoreServiceFactory() {
+	}
+
 	/** 
 	 * The default namespace is the one used by Objectify for its cache.  You can reset it.
 	 */

--- a/src/main/java/com/googlecode/objectify/impl/TypeUtils.java
+++ b/src/main/java/com/googlecode/objectify/impl/TypeUtils.java
@@ -27,6 +27,9 @@ public class TypeUtils
 		PRIMITIVE_TO_WRAPPER.put(char.class, Character.class);
 	}
 
+	private TypeUtils() {
+	}
+
 	/**
 	 * Throw an IllegalStateException if the class does not have a no-arg constructor.
 	 */

--- a/src/main/java/com/googlecode/objectify/impl/translate/opt/joda/JodaMoneyTranslators.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/opt/joda/JodaMoneyTranslators.java
@@ -15,6 +15,9 @@ import com.googlecode.objectify.ObjectifyFactory;
  */
 public class JodaMoneyTranslators
 {
+	private JodaMoneyTranslators() {
+	}
+
 	public static void add(ObjectifyFactory fact) {
 		fact.getTranslators().add(new MoneyStringTranslatorFactory());
 		fact.getTranslators().add(new BigMoneyStringTranslatorFactory());

--- a/src/main/java/com/googlecode/objectify/impl/translate/opt/joda/JodaTimeTranslators.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/opt/joda/JodaTimeTranslators.java
@@ -15,6 +15,9 @@ import com.googlecode.objectify.ObjectifyFactory;
  */
 public class JodaTimeTranslators
 {
+	private JodaTimeTranslators() {
+	}
+
 	public static void add(ObjectifyFactory fact) {
 		fact.getTranslators().add(new ReadableInstantTranslatorFactory());
 		fact.getTranslators().add(new ReadablePartialTranslatorFactory());

--- a/src/main/java/com/googlecode/objectify/repackaged/gentyref/GenericTypeReflector.java
+++ b/src/main/java/com/googlecode/objectify/repackaged/gentyref/GenericTypeReflector.java
@@ -21,7 +21,10 @@ import java.util.Set;
  */
 public class GenericTypeReflector {
 	private static final Type UNBOUND_WILDCARD = new WildcardTypeImpl(new Type[]{Object.class}, new Type[]{});
-	
+
+	private GenericTypeReflector() {
+	}
+
 	/**
 	 * Returns the erasure of the given type.
 	 */

--- a/src/main/java/com/googlecode/objectify/repackaged/gentyref/TypeFactory.java
+++ b/src/main/java/com/googlecode/objectify/repackaged/gentyref/TypeFactory.java
@@ -15,7 +15,10 @@ import java.lang.reflect.WildcardType;
  */
 public class TypeFactory {
 	private static final WildcardType UNBOUND_WILDCARD = new WildcardTypeImpl(new Type[]{Object.class}, new Type[]{});
-	
+
+	private TypeFactory() {
+	}
+
 	/**
 	 * Creates a type of class <tt>clazz</tt> with <tt>arguments</tt> as type arguments.
 	 * <p>

--- a/src/main/java/com/googlecode/objectify/util/DatastoreIntrospector.java
+++ b/src/main/java/com/googlecode/objectify/util/DatastoreIntrospector.java
@@ -39,4 +39,7 @@ public class DatastoreIntrospector
 			}
 		}
 	}
+
+	private DatastoreIntrospector() {
+	}
 }

--- a/src/main/java/com/googlecode/objectify/util/DatastoreUtils.java
+++ b/src/main/java/com/googlecode/objectify/util/DatastoreUtils.java
@@ -19,6 +19,9 @@ import java.util.List;
  */
 public class DatastoreUtils
 {
+	private DatastoreUtils() {
+	}
+
 	/**
 	 * Turn a list of refs into a list of raw keys.
 	 */

--- a/src/main/java/com/googlecode/objectify/util/FutureHelper.java
+++ b/src/main/java/com/googlecode/objectify/util/FutureHelper.java
@@ -18,6 +18,9 @@ import java.util.concurrent.Future;
  */
 public class FutureHelper
 {
+	private FutureHelper() {
+	}
+
 	/** Quietly perform the get() on a future */
 	public static <T> T quietGet(Future<T> future)
 	{

--- a/src/main/java/com/googlecode/objectify/util/GenericUtils.java
+++ b/src/main/java/com/googlecode/objectify/util/GenericUtils.java
@@ -10,6 +10,9 @@ import java.util.Map;
  */
 public class GenericUtils
 {
+	private GenericUtils() {
+	}
+
 	/**
 	 * Get the component type of a Collection.
 	 */

--- a/src/main/java/com/googlecode/objectify/util/LogUtils.java
+++ b/src/main/java/com/googlecode/objectify/util/LogUtils.java
@@ -14,7 +14,10 @@ public class LogUtils
 {
 	/** */
 	static final int PATH_PADDING = 13;
-	
+
+	private LogUtils() {
+	}
+
 	/** Create a log a message for a given path */
 	public static String msg(Path path, String msg) {
 		StringBuilder bld = new StringBuilder();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.