### PR TITLE
"equals(Object obj)" should test argument type

### DIFF
--- a/src/main/java/com/googlecode/objectify/cache/EntityMemcache.java
+++ b/src/main/java/com/googlecode/objectify/cache/EntityMemcache.java
@@ -128,7 +128,12 @@ public class EntityMemcache
 
 		/** */
 		@Override
-		public boolean equals(Object obj) { return this.key.equals(((Bucket)obj).key); }
+		public boolean equals(Object obj) {
+			if (this.getClass() != obj.getClass())
+				return false;
+				
+			return this.key.equals(((Bucket)obj).key); 
+		}
 
 		/** */
 		@Override

--- a/src/main/java/com/googlecode/objectify/impl/translate/TypeKey.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/TypeKey.java
@@ -55,6 +55,9 @@ public class TypeKey<T>
 
 	@Override
 	public boolean equals(Object obj) {
+		if (this.getClass() != obj.getClass())
+			return false;
+			
 		TypeKey other = (TypeKey)obj;
 
 		return type.equals(other.type) && Arrays.equals(annotations, other.annotations);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2097 - “ "equals(Object obj)" should test argument type ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2097
Please let me know if you have any questions.
Ayman Abdelghany.