### PR TITLE
Added basic validation for entitiy properties

### DIFF
--- a/src/main/java/com/googlecode/objectify/annotation/NotNullOrEmpty.java
+++ b/src/main/java/com/googlecode/objectify/annotation/NotNullOrEmpty.java
@@ -1,0 +1,19 @@
+package com.googlecode.objectify.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Check whether the property is null or empty
+ * 
+ * A ValidationException is thrown, if the annotated property is null or empty.
+ * 
+ * @author Hendrik Pilz <hepisec@gmail.com>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface NotNullOrEmpty {
+    
+}

--- a/src/main/java/com/googlecode/objectify/annotation/PossibleValues.java
+++ b/src/main/java/com/googlecode/objectify/annotation/PossibleValues.java
@@ -1,0 +1,20 @@
+package com.googlecode.objectify.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Check if the property value is one of the given values
+ * 
+ * A ValidationException is thrown if the value of the annotated property is not
+ * in the list of possible values
+ * 
+ * @author Hendrik Pilz <hepisec@gmail.com>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface PossibleValues {
+    String[] value();
+}

--- a/src/main/java/com/googlecode/objectify/util/ValidatingEntity.java
+++ b/src/main/java/com/googlecode/objectify/util/ValidatingEntity.java
@@ -1,0 +1,128 @@
+package com.googlecode.objectify.util;
+
+import com.googlecode.objectify.annotation.NotNullOrEmpty;
+import com.googlecode.objectify.annotation.OnSave;
+import com.googlecode.objectify.annotation.PossibleValues;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Entities which use validation annotations must extend this class
+ * 
+ * @author Hendrik Pilz <hepisec@gmail.com>
+ */
+public abstract class ValidatingEntity {
+
+    private static final Logger log = Logger.getLogger(ValidatingEntity.class.getName());
+    
+    /**
+     * This method is called by Objectify and starts the validation of the entity
+     * 
+     * @throws ValidationException 
+     */
+    @OnSave
+    public void validate() throws ValidationException {
+        log.log(Level.FINE, "Validating {0} entity.", this.getClass().getSimpleName());
+        Field[] fields = this.getClass().getDeclaredFields();
+
+        for (Field field : fields) {
+            validate(field);
+        }
+    }
+
+    /**
+     * Validate a certain field
+     * 
+     * @param field
+     * @throws ValidationException 
+     */
+    public void validate(Field field) throws ValidationException {
+        log.log(Level.FINE, "Validating field {0}", field.getName());
+        Method getMethod = getGetter(field);
+
+        if (getMethod == null) {
+            log.log(Level.FINE, "Field {0} has no associated method {1}", new Object[]{field.getName(), getGetter(field)});
+            return;
+        }
+
+        try {
+            Object value = getMethod.invoke(this);
+            validateNotNullOrEmpty(field, value);
+            validatePossibleValues(field, value);
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+            log.log(Level.SEVERE, null, ex);
+        }
+    }
+
+    /**
+     * Check whether the property is null or empty
+     * 
+     * A ValidationException is thrown, if the annotated property is null or empty.
+     * 
+     * @param field
+     * @param value
+     * @throws ValidationException 
+     */
+    public void validateNotNullOrEmpty(Field field, Object value) throws ValidationException {
+        if (field.isAnnotationPresent(NotNullOrEmpty.class)) {
+            log.log(Level.FINE, "Validating NotNullOrEmpty on {0}", field.getName());
+    
+            if (value == null) {
+                throw new ValidationException(field.getName() + " must not be null!");
+            }
+
+            if (field.getType().equals(String.class)) {
+                String sValue = (String) value;
+
+                if (sValue.isEmpty()) {
+                    throw new ValidationException(field.getName() + " must not be empty!");
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if the property value is one of the given values
+     * 
+     * A ValidationException is thrown if the value of the annotated property is not
+     * in the list of possible values
+     * 
+     * @param field
+     * @param value
+     * @throws ValidationException 
+     */
+    public void validatePossibleValues(Field field, Object value) throws ValidationException {
+        PossibleValues possibleValues = field.getAnnotation(PossibleValues.class);
+        
+        if (possibleValues == null) {
+            return;
+        }
+        
+        log.log(Level.FINE, "Validating PossibleValues on {0}", field.getName());
+        String[] values = possibleValues.value();
+        
+        for (String v : values) {
+            if (v.equals(value)) {
+                return;
+            }
+        }
+        
+        throw new ValidationException("The value " + value.toString() + " is not allowed for " + field.getName());
+    }
+
+    private Method getGetter(Field field) {
+        String name = field.getName();
+        String methodName = "get" + name.substring(0, 1).toUpperCase() + name.substring(1);
+        log.log(Level.FINE, "Check for method {0}", methodName);
+
+        try {
+            Method getMethod = this.getClass().getDeclaredMethod(methodName);
+            return getMethod;
+        } catch (NoSuchMethodException | SecurityException ex) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/googlecode/objectify/util/ValidationException.java
+++ b/src/main/java/com/googlecode/objectify/util/ValidationException.java
@@ -1,0 +1,23 @@
+package com.googlecode.objectify.util;
+
+/**
+ *
+ * @author Hendrik Pilz <hepisec@gmail.com>
+ */
+public class ValidationException extends Exception {
+    public ValidationException() {
+        super();
+    }
+    
+    public ValidationException(String msg) {
+        super(msg);
+    }
+    
+    public ValidationException(Throwable cause) {
+        super(cause);
+    }
+    
+    public ValidationException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/test/java/com/googlecode/objectify/test/ValidationTest.java
+++ b/src/test/java/com/googlecode/objectify/test/ValidationTest.java
@@ -1,0 +1,71 @@
+package com.googlecode.objectify.test;
+
+import com.googlecode.objectify.SaveException;
+import com.googlecode.objectify.test.entity.EntityWithValidation;
+import com.googlecode.objectify.test.util.TestBase;
+import org.testng.annotations.Test;
+import java.util.logging.Logger;
+import static com.googlecode.objectify.test.util.TestObjectifyService.fact;
+import static com.googlecode.objectify.test.util.TestObjectifyService.ofy;
+import static org.testng.Assert.*;
+
+/**
+ * Tests of entity validation
+ *
+ * @author Hendrik Pilz <hepisec@gmail.com>
+ */
+public class ValidationTest extends TestBase {
+
+    /**
+     *      
+     */
+    @SuppressWarnings("unused")
+    private static Logger log = Logger.getLogger(ValidationTest.class.getName());
+
+    @Test(expectedExceptions = SaveException.class)
+    public void notNullValidation() {
+        fact().register(EntityWithValidation.class);
+        EntityWithValidation ent = new EntityWithValidation();
+        ent.setNotNull(null);
+        ofy().save().entity(ent).now();
+    }
+
+    @Test(expectedExceptions = SaveException.class)
+    public void notEmptyValidation() {
+        fact().register(EntityWithValidation.class);
+        EntityWithValidation ent = new EntityWithValidation();
+        ent.setNotNull("");
+        ofy().save().entity(ent).now();
+    }    
+    
+    @Test
+    public void notNullOrEmptyValidationWithValue() {
+        fact().register(EntityWithValidation.class);
+        assertEquals(0, ofy().load().type(EntityWithValidation.class).count());
+        EntityWithValidation ent = new EntityWithValidation();
+        ent.setNotNull("Name");
+        ent.setNumber("one");
+        ofy().save().entity(ent).now();
+        assertEquals(1, ofy().load().type(EntityWithValidation.class).count());
+    }    
+    
+    @Test(expectedExceptions = SaveException.class)
+    public void possibleValueValidation() {
+        fact().register(EntityWithValidation.class);
+        EntityWithValidation ent = new EntityWithValidation();
+        ent.setNotNull("Name");
+        ent.setNumber("4");
+        ofy().save().entity(ent).now();
+    }
+    
+    @Test
+    public void possibleValueValidationWithCorrectValue() {
+        fact().register(EntityWithValidation.class);
+        assertEquals(0, ofy().load().type(EntityWithValidation.class).count());
+        EntityWithValidation ent = new EntityWithValidation();
+        ent.setNotNull("Name");
+        ent.setNumber("one");
+        ofy().save().entity(ent).now();
+        assertEquals(1, ofy().load().type(EntityWithValidation.class).count());
+    }    
+}

--- a/src/test/java/com/googlecode/objectify/test/entity/EntityWithValidation.java
+++ b/src/test/java/com/googlecode/objectify/test/entity/EntityWithValidation.java
@@ -1,0 +1,45 @@
+package com.googlecode.objectify.test.entity;
+
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.NotNullOrEmpty;
+import com.googlecode.objectify.annotation.PossibleValues;
+import com.googlecode.objectify.util.ValidatingEntity;
+
+/**
+ *
+ * @author Hendrik Pilz <hepisec@gmail.com>
+ */
+@Entity
+public class EntityWithValidation extends ValidatingEntity {
+    @Id
+    private Long id;
+    @NotNullOrEmpty
+    private String notNull;
+    @PossibleValues({"one", "two", "three"})
+    private String number;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNotNull() {
+        return notNull;
+    }
+
+    public void setNotNull(String notNull) {
+        this.notNull = notNull;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }    
+}


### PR DESCRIPTION
Hi, I've added a basic validation feature based on the @OnSave hook. It currently requires entities to extend ValidatingEntity. The currently implemented validations are @NotNullOrEmpty and @PossibleValues. One can call an entity's validate() method directly to validate the properties before trying to store them.
