### PR TITLE
Support loading entities with member field of type `Number`.

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/translate/NumberTranslatorFactory.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/NumberTranslatorFactory.java
@@ -56,7 +56,8 @@ public class NumberTranslatorFactory implements TranslatorFactory<Number, Object
 	 */
 	private Number coerceNumber(Number value, Class<?> type)
 	{
-		if (type == Byte.class) return value.byteValue();
+		if (type == Number.class) return value;
+		else if (type == Byte.class) return value.byteValue();
 		else if (type == Short.class) return value.shortValue();
 		else if (type == Integer.class) return value.intValue();
 		else if (type == Long.class) return value.longValue();


### PR DESCRIPTION
If you have an entity class with a member field of type `java.lang.Number`, objectify will fail 
to load such an entity from Datastore, throwing `IllegalArgumentException` inside
`NumberTranslatorFactory`. That's because the translator assumes that the type will always
be a subclass of `Number`. This diff fixes the problem by returning the value as-is if the 
requested type is `Number`.