### PR TITLE
Objectify endpoints-framework 2.0.0 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>19.0</version>
 		</dependency>
 
 		<!-- Optional -->


### PR DESCRIPTION
To enable a frictionless support to `com.google.endpoints:endpoints-framework:2.0.0`, the Guava dependency of Objectify framework must be upgraded to version 19.0.

Now objectify depends on Guava 18.0 which conflicts causing `java.lang.NoSuchMethodError: com.google.common.reflect.TypeToken` and after `java.lang.NullPointerException at com.google.api.server.spi.EndpointsServlet.service(EndpointsServlet.java:72)` when deploying an application with the new google endpoints framework 2.0.

The workaround is to exclude the guava dependency from objectify changing the pom:
``` xml
<dependency>
	<groupId>com.googlecode.objectify</groupId>
	<artifactId>objectify</artifactId>
	<version>${objectify.version}</version>
	<exclusions>
		<exclusion>
			<groupId>com.google.guava</groupId>
			<artifactId>guava</artifactId>
		</exclusion>
	</exclusions>
</dependency>
```

by merging this pull request I can remove the exclusion in the next release, hopefully.