### PR TITLE
Quality of life improvements for Objectify v6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<junit.platform.version>1.0.3</junit.platform.version>
 	</properties>
 
-	<groupId>com.streak.objectify</groupId>
+	<groupId>com.googlecode.objectify</groupId>
 	<artifactId>objectify</artifactId>
 	<version>6.1-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<junit.platform.version>1.0.3</junit.platform.version>
 	</properties>
 
-	<groupId>com.googlecode.objectify</groupId>
+	<groupId>com.streak.objectify</groupId>
 	<artifactId>objectify</artifactId>
 	<version>6.1-SNAPSHOT</version>
 

--- a/src/main/java/com/googlecode/objectify/cache/CachingAsyncTransaction.java
+++ b/src/main/java/com/googlecode/objectify/cache/CachingAsyncTransaction.java
@@ -7,6 +7,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.ReadOption;
 import com.google.cloud.datastore.Transaction.Response;
+import com.google.protobuf.ByteString;
 import com.googlecode.objectify.Result;
 import com.googlecode.objectify.impl.AsyncTransaction;
 import com.googlecode.objectify.impl.PrivateAsyncTransaction;
@@ -118,6 +119,11 @@ public class CachingAsyncTransaction extends CachingAsyncDatastoreReaderWriter i
 	@Override
 	public void listenForCommit(final Runnable listener) {
 		raw.listenForCommit(listener);
+	}
+
+	@Override
+	public ByteString getTransactionHandle() {
+		return raw.getTransactionHandle();
 	}
 
 	@Override

--- a/src/main/java/com/googlecode/objectify/impl/AsyncTransaction.java
+++ b/src/main/java/com/googlecode/objectify/impl/AsyncTransaction.java
@@ -1,6 +1,7 @@
 package com.googlecode.objectify.impl;
 
 import com.google.cloud.datastore.Transaction.Response;
+import com.google.protobuf.ByteString;
 
 /**
  * The new datastore SDK has a neat structure of interfaces and implementations (transaction, datastorereader, etc)
@@ -16,4 +17,6 @@ public interface AsyncTransaction extends AsyncDatastoreReaderWriter {
 	void rollback();
 
 	void listenForCommit(final Runnable listener);
+
+	ByteString getTransactionHandle();
 }

--- a/src/main/java/com/googlecode/objectify/impl/AsyncTransactionImpl.java
+++ b/src/main/java/com/googlecode/objectify/impl/AsyncTransactionImpl.java
@@ -2,6 +2,7 @@ package com.googlecode.objectify.impl;
 
 import com.google.cloud.datastore.Transaction;
 import com.google.cloud.datastore.Transaction.Response;
+import com.google.protobuf.ByteString;
 import com.googlecode.objectify.Result;
 import lombok.Getter;
 
@@ -59,6 +60,11 @@ public class AsyncTransactionImpl extends AsyncDatastoreReaderWriterImpl impleme
 	@Override
 	public void listenForCommit(final Runnable listener) {
 		listeners.add(listener);
+	}
+
+	@Override
+	public ByteString getTransactionHandle() {
+		return transaction.getTransactionId();
 	}
 
 	@Override

--- a/src/main/java/com/googlecode/objectify/impl/HybridQueryResults.java
+++ b/src/main/java/com/googlecode/objectify/impl/HybridQueryResults.java
@@ -65,12 +65,12 @@ public class HybridQueryResults<T> implements QueryResults<T> {
 	}
 
 	/** Detects Integer.MAX_VALUE and prevents OOM exceptions */
-	private <T> Iterator<Iterator<T>> safePartition(final Iterator<T> input, final int chunkSize) {
-		// Iterators.partition() allocates lists with capacity of whatever batch size you pass in; if batch
-		// size is unlimited, we end up trying to allocate maxint.
-		return (chunkSize == Integer.MAX_VALUE)
-				? Iterators.singletonIterator(input)
-				: Iterators.transform(Iterators.partition(input, chunkSize), IterateFunction.instance());
+	private <T> Iterator<Iterator<T>> safePartition(final Iterator<T> input, int chunkSize) {
+		// Cloud Datastore library errors if you try to fetch more than 1000 keys at a time
+		if (chunkSize > 1000) {
+			chunkSize = 1000;
+		}
+		return Iterators.transform(Iterators.partition(input, chunkSize), IterateFunction.instance());
 	}
 
 	/** Loads them; note that it's possible for some loaded results to be null */

--- a/src/main/java/com/googlecode/objectify/util/KeyFormat.java
+++ b/src/main/java/com/googlecode/objectify/util/KeyFormat.java
@@ -115,6 +115,9 @@ public enum KeyFormat {
         byte[] userKey = Base64.decodeBase64(urlsafeKey);
         DynamicMessage userKeyMessage = DynamicMessage.newBuilder(referenceDescriptor).mergeFrom(userKey).build();
         String app = (String) userKeyMessage.getField(referenceDescriptor.findFieldByName("app"));
+        if (app.startsWith("s~")) {
+            app = app.substring(2);
+        }
         // TODO(frew): Does Google Cloud Datastore have the concept of namespace?
         // String namespace = (String) userKeyMessage.getField(referenceDescriptor.findFieldByName("name_space"));
         DynamicMessage path = (DynamicMessage) userKeyMessage.getField(referenceDescriptor.findFieldByName("path"));
@@ -150,7 +153,11 @@ public enum KeyFormat {
     public String formatOldStyleAppEngineKey(Key key) {
         Descriptors.Descriptor referenceDescriptor = keyDescriptor.findMessageTypeByName("Reference");
         DynamicMessage.Builder keyMessageBuilder = DynamicMessage.newBuilder(referenceDescriptor);
-        keyMessageBuilder.setField(referenceDescriptor.findFieldByName("app"), key.getProjectId());
+        String fullProjectId = key.getProjectId();
+        if (!fullProjectId.startsWith("s~")) {
+            fullProjectId = "s~" + fullProjectId;
+        }
+        keyMessageBuilder.setField(referenceDescriptor.findFieldByName("app"), fullProjectId);
         Descriptors.Descriptor elementDescriptor = keyDescriptor.findMessageTypeByName("Element");
 
         List<DynamicMessage> elementMessages = new ArrayList<>();


### PR DESCRIPTION
Sorry for the poor pull etiquette here in batching updates. Can separate into multiple pieces or pull things out if it would be helpful. This is from migrating Streak's codebase to v6 which we're currently deploying.

Changes:
1) Add and remove s~ when converting from legacy url safe (Cloud Datastore doesn't use s~ prefix, there are a couple places where we need the legacy url safe keys to match by string comparison).
2) Expose the TransactionHandle (needed for our Spanner dual-writing configuration).
3) Make HybridQueryResults.safePartition always partition at max 1000. Cloud Datastore fails the request if it asks for more than 1000 keys in one go, so I think this is the correct fix.
4) Make SerializeTranslatorFactory hold on to the first exception when deserializing before it tries to do it again with the alternate value for the zip annotation. This helps with debugging (e.g. lets you know whether the serialization UID didn't match).