### PR TITLE
Perf optimization by caching reflection based results

### DIFF
--- a/src/main/java/com/googlecode/objectify/Key.java
+++ b/src/main/java/com/googlecode/objectify/Key.java
@@ -1,10 +1,12 @@
 package com.googlecode.objectify;
 
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.common.collect.Maps;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.impl.TypeUtils;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * <p>A typesafe wrapper for the datastore Key object.</p>
@@ -238,6 +240,8 @@ public class Key<T> implements Serializable, Comparable<Key<?>>
 		else
 			return typed.getRaw();
 	}
+	
+	private static final Map<Class<?>, String> kindCache = Maps.newConcurrentMap();
 
 	/**
 	 * <p>Determines the kind for a Class, as understood by the datastore.  The first class in a
@@ -246,11 +250,15 @@ public class Key<T> implements Serializable, Comparable<Key<?>>
 	 * <p>If no @Entity annotation is found, just uses the simplename as is.</p>
 	 */
 	public static String getKind(Class<?> clazz) {
-		String kind = getKindRecursive(clazz);
-		if (kind == null)
-			return clazz.getSimpleName();
-		else
-			return kind;
+		String kind = kindCache.get(clazz);
+		if (kind == null) {
+			kind = getKindRecursive(clazz);
+			if (kind == null) {
+				kind = clazz.getSimpleName();
+			}
+			kindCache.put(clazz, kind);
+		}
+		return kind;
 	}
 
 	/**

--- a/src/main/java/com/googlecode/objectify/impl/TypeUtils.java
+++ b/src/main/java/com/googlecode/objectify/impl/TypeUtils.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.collect.Maps;
+
 /**
  */
 public class TypeUtils
@@ -30,13 +32,20 @@ public class TypeUtils
 	private TypeUtils() {
 	}
 
+	private static final Map<Class<?>, Constructor<?>> noArgConstructorCache = Maps.newConcurrentMap();
+	
 	/**
 	 * Throw an IllegalStateException if the class does not have a no-arg constructor.
 	 */
 	public static <T> Constructor<T> getNoArgConstructor(Class<T> clazz) {
 		try {
-			Constructor<T> ctor = clazz.getDeclaredConstructor(new Class[0]);
-			ctor.setAccessible(true);
+			@SuppressWarnings("unchecked")
+			Constructor<T> ctor = (Constructor<T>) noArgConstructorCache.get(clazz);
+			if (ctor == null) {
+				ctor = clazz.getDeclaredConstructor(new Class[0]);
+				ctor.setAccessible(true);
+				noArgConstructorCache.put(clazz, ctor);
+			}
 			return ctor;
 		}
 		catch (NoSuchMethodException e) {


### PR DESCRIPTION
Microbenchmarking these are kinda pointless, as they are obviously much faster, but the original trigger was profiling unit/component/integration tests that originally took almost 20 min to run (without any remote call). These methods used a significant amount of CPU for such trivial, cacheable calculations. Post-modification execution times went down by more than 10%.