### PR TITLE
Avoid reiterating the entities when saving

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/WriteEngine.java
+++ b/src/main/java/com/googlecode/objectify/impl/WriteEngine.java
@@ -65,8 +65,11 @@ public class WriteEngine
 
 		final SaveContext ctx = new SaveContext();
 
+		// Need to make a copy of the original list because someone might clear it while we are async
+		final List<? extends E> original = Lists.newArrayList(entities);
+
 		final List<Entity> entityList = new ArrayList<>();
-		for (E obj: entities) {
+		for (E obj: original) {
 			if (obj == null)
 				throw new NullPointerException("Attempted to save a null entity");
 
@@ -79,9 +82,6 @@ public class WriteEngine
 				entityList.add(metadata.save(obj, ctx));
 			}
 		}
-
-		// Need to make a copy of the original list because someone might clear it while we are async
-		final List<? extends E> original = Lists.newArrayList(entities);
 
 		// The CachingDatastoreService needs its own raw transaction
 		Future<List<com.google.appengine.api.datastore.Key>> raw = ads.put(getTransactionRaw(), entityList);

--- a/src/test/java/com/googlecode/objectify/test/SaveTests.java
+++ b/src/test/java/com/googlecode/objectify/test/SaveTests.java
@@ -1,0 +1,70 @@
+package com.googlecode.objectify.test;
+
+import static com.googlecode.objectify.ObjectifyService.factory;
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.annotation.Cache;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.OnSave;
+import com.googlecode.objectify.impl.WriteEngine;
+import com.googlecode.objectify.test.util.TestBase;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+public class SaveTests extends TestBase {
+
+	/**
+	 * The {@link WriteEngine} previously iterated twice on the {@link Iterables}
+	 * passed as argument. If the iterable doesn't return the same set of entities
+	 * upon the second iteration, it can lead to problems.
+	 * 
+	 * This can easily happen if there's a filtering iterable that uses a predicate
+	 * relying on a property changed by an {@link OnSave} hook.
+	 */
+	@Test
+	public void testSaveChangingIterable() {
+		factory().register(EntityWithOnSave.class);
+		List<EntityWithOnSave> entities = Lists.newArrayList(new EntityWithOnSave(1L, null));
+		Iterable<EntityWithOnSave> entitiesWithoutDefaultValue = Iterables.filter(entities,
+				new Predicate<EntityWithOnSave>() {
+					@Override
+					public boolean apply(EntityWithOnSave entity) {
+						return entity.getSomeValue() == null;
+					}
+				});
+		Map<Key<EntityWithOnSave>, EntityWithOnSave> saveResult = ofy().save().entities(entitiesWithoutDefaultValue)
+				.now();
+		assert 1 == saveResult.size();
+	}
+
+	@Entity
+	@Cache
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class EntityWithOnSave {
+		@Id
+		private Long id;
+
+		private String someValue;
+
+		@OnSave
+		public void onSave() {
+			if (someValue == null) {
+				someValue = "some calculated default value";
+			}
+		}
+	}
+}


### PR DESCRIPTION
(see the description of the case in the javadoc of the test)