### PR TITLE
[414] Fixed deleting by long vararg ids

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/DeferredDeleteTypeImpl.java
+++ b/src/main/java/com/googlecode/objectify/impl/DeferredDeleteTypeImpl.java
@@ -4,6 +4,7 @@ import com.googlecode.objectify.Key;
 import com.googlecode.objectify.ObjectifyFactory;
 import com.googlecode.objectify.cmd.DeferredDeleteIds;
 import com.googlecode.objectify.cmd.DeferredDeleteType;
+import com.googlecode.objectify.util.ArrayUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +60,7 @@ class DeferredDeleteTypeImpl implements DeferredDeleteType
 
 	@Override
 	public void ids(final long... ids) {
-		ids(Arrays.asList(ids));
+		ids(ArrayUtils.asList(ids));
 	}
 
 	@Override

--- a/src/main/java/com/googlecode/objectify/impl/DeleteTypeImpl.java
+++ b/src/main/java/com/googlecode/objectify/impl/DeleteTypeImpl.java
@@ -5,6 +5,7 @@ import com.googlecode.objectify.ObjectifyFactory;
 import com.googlecode.objectify.Result;
 import com.googlecode.objectify.cmd.DeleteIds;
 import com.googlecode.objectify.cmd.DeleteType;
+import com.googlecode.objectify.util.ArrayUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,7 +77,7 @@ class DeleteTypeImpl implements DeleteType
 	 */
 	@Override
 	public Result<Void> ids(final long... ids) {
-		return ids(Arrays.asList(ids));
+		return ids(ArrayUtils.asList(ids));
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/com/googlecode/objectify/util/ArrayUtils.java
+++ b/src/main/java/com/googlecode/objectify/util/ArrayUtils.java
@@ -1,0 +1,28 @@
+package com.googlecode.objectify.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class ArrayUtils {
+
+	private ArrayUtils() {
+	}
+
+	/**
+	 * Copies an array of primitive longs while boxing them at the same time,
+	 * and then converting into a list. Can't use {@link Arrays#asList(Object[])}
+	 * directly as that will create a list of arrays instead.
+	 *
+	 * @param elements The array of primitive longs to convert to a list
+	 * @return A list of boxed {@link long} values
+	 */
+	public static List<Long> asList(long... elements) {
+		Objects.requireNonNull(elements);
+		Long[] copy = new Long[elements.length];
+		for (int index = 0; index < elements.length; index++) {
+			copy[index] = elements[index];
+		}
+		return Arrays.asList(copy);
+	}
+}

--- a/src/test/java/com/googlecode/objectify/test/BasicTests.java
+++ b/src/test/java/com/googlecode/objectify/test/BasicTests.java
@@ -188,6 +188,26 @@ class BasicTests extends TestBase {
 
 	/** */
 	@Test
+	void entitiesCanBeDeletedInBatchOfPrimitiveIds() throws Exception {
+		factory().register(Trivial.class);
+
+		final Trivial triv1 = new Trivial("foo5", 5);
+		final Trivial triv2 = new Trivial("foo6", 6);
+		triv1.setId(12345L);
+		triv2.setId(12346L);
+
+		ofy().save().entities(triv1, triv2).now();
+
+		assertThat(ofy().load().entities(triv1, triv2)).hasSize(2);
+
+		ofy().delete().type(Trivial.class).ids(12345L, 12346L).now();
+
+		final Map<Key<Trivial>, Trivial> result = ofy().load().entities(triv1, triv2);
+		assertThat(result).isEmpty();
+	}
+
+	/** */
+	@Test
 	void loadWithManuallyCreatedKey() throws Exception {
 		factory().register(Trivial.class);
 

--- a/src/test/java/com/googlecode/objectify/test/DeferTests.java
+++ b/src/test/java/com/googlecode/objectify/test/DeferTests.java
@@ -45,6 +45,25 @@ class DeferTests extends TestBase {
 
 	/** */
 	@Test
+	void deferredSaveAndDeleteWithPrimitiveIdsArray() throws Exception {
+		final Trivial triv1 = new Trivial("foo", 5);
+		final Trivial triv2 = new Trivial("foo", 5);
+		triv1.setId(12345L);
+		triv2.setId(12346L);
+
+		try (final Closeable root = ObjectifyService.begin()) {
+			ofy().defer().save().entities(triv1, triv2);
+			assertThat(ofy().load().entity(triv1).now()).isEqualTo(triv1);
+			assertThat(ofy().load().entity(triv2).now()).isEqualTo(triv2);
+
+			ofy().defer().delete().type(Trivial.class).ids(12345L, 12346L);
+			assertThat(ofy().load().entity(triv1).now()).isNull();
+			assertThat(ofy().load().entity(triv2).now()).isNull();
+		}
+	}
+
+	/** */
+	@Test
 	void deferredSaveAndDeleteProcessedAtEndOfRequest() throws Exception {
 
 		final Trivial triv = new Trivial(123L, "foo", 5);


### PR DESCRIPTION
Fixed an issue where a vararg long array was not being autoboxed when converting to a list of Long types, making it impossible to delete entities by their long id keys.

The only two solutions I could think of were either either changing the method signature to `Long...` and then passing that into `Arrays.asList`, or creating a utility class to autobox the array elements and then convert to a list. The first option would not be backwards compatible, so I went with the utility class.