### PR TITLE
Fix exception message for transaction type NEVER

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/TransactorYes.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactorYes.java
@@ -58,7 +58,7 @@ class TransactorYes extends Transactor
 				return transactionless(parent, work);
 
 			case NEVER:
-				throw new IllegalStateException("MANDATORY transaction but no transaction present");
+				throw new IllegalStateException("NEVER transaction type but transaction present");
 
 			case REQUIRES_NEW:
 				return transactNew(parent, Transactor.DEFAULT_TRY_LIMIT, work);


### PR DESCRIPTION
In case a transaction type NEVER was encountered from within a transaction it would wrongly indicate that a MANDATORY transaction was not present. Not sure if the proposed exception message is okay. I've added the word "type" to the message, as without it it would seem like there's something like a "NEVER transaction", which made no sense to me.