### PR TITLE
Fix key id type for null ids

### DIFF
--- a/src/main/java/com/googlecode/objectify/Key.java
+++ b/src/main/java/com/googlecode/objectify/Key.java
@@ -165,9 +165,9 @@ public class Key<T> implements Serializable, Comparable<Key<?>>
 	}
 
 	/**
-	 * @return the id associated with this key, or 0 if this key has a name.
+	 * @return the id associated with this key, or null if this key has a name.
 	 */
-	public long getId() {
+	public Long getId() {
 		return this.raw.getId();
 	}
 


### PR DESCRIPTION
The new client library returns [null rather than 0](https://googleapis.dev/java/google-cloud-datastore/latest/com/google/cloud/datastore/Key.html#getId--)

Without this you just get a null pointer exception.