### PR TITLE
Manages datastore contention with exponential backoff [v5]

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/ObjectifyImpl.java
+++ b/src/main/java/com/googlecode/objectify/impl/ObjectifyImpl.java
@@ -208,7 +208,7 @@ public class ObjectifyImpl<O extends Objectify> implements Objectify, Cloneable
 	 */
 	@Override
 	public <R> R transactNew(Work<R> work) {
-		return this.transactNew(Integer.MAX_VALUE, work);
+		return this.transactNew(Transactor.DEFAULT_TRY_LIMIT, work);
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/com/googlecode/objectify/impl/Transactor.java
+++ b/src/main/java/com/googlecode/objectify/impl/Transactor.java
@@ -12,6 +12,9 @@ import com.googlecode.objectify.Work;
  */
 abstract public class Transactor<O extends Objectify>
 {
+	// Limit default number of retries to something high but non-infinite
+	public static final int DEFAULT_TRY_LIMIT = 200;
+	
 	/** Our session */
 	protected Session session;
 

--- a/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
@@ -91,6 +91,7 @@ public class TransactorNo<O extends Objectify> extends Transactor<O>
 	@Override
 	public <R> R transactNew(ObjectifyImpl<O> parent, int limitTries, Work<R> work) {
 		Preconditions.checkArgument(limitTries >= 1);
+		final int ORIGINAL_TRIES = limitTries;
 
 		while (true) {
 			try {
@@ -102,6 +103,11 @@ public class TransactorNo<O extends Objectify> extends Transactor<O>
 
 					if (log.isLoggable(Level.FINEST))
 						log.log(Level.FINEST, "Details of optimistic concurrency failure", ex);
+					try {
+						// Do increasing backoffs with randomness
+						Thread.sleep(Math.min(10000, (long) (0.5 * Math.random() + 0.5) * 200 * (ORIGINAL_TRIES - limitTries + 2)));
+					} catch (InterruptedException ignored) {
+					}
 				} else {
 					throw ex;
 				}

--- a/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
@@ -107,6 +107,7 @@ public class TransactorNo<O extends Objectify> extends Transactor<O>
 						// Do increasing backoffs with randomness
 						Thread.sleep(Math.min(10000, (long) (0.5 * Math.random() + 0.5) * 200 * (ORIGINAL_TRIES - limitTries + 2)));
 					} catch (InterruptedException ignored) {
+						throw ex;
 					}
 				} else {
 					throw ex;

--- a/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactorNo.java
@@ -82,7 +82,7 @@ public class TransactorNo<O extends Objectify> extends Transactor<O>
 	 */
 	@Override
 	public <R> R transact(ObjectifyImpl<O> parent, Work<R> work) {
-		return this.transactNew(parent, Integer.MAX_VALUE, work);
+		return this.transactNew(parent, DEFAULT_TRY_LIMIT, work);
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/com/googlecode/objectify/impl/TransactorYes.java
+++ b/src/main/java/com/googlecode/objectify/impl/TransactorYes.java
@@ -86,7 +86,7 @@ public class TransactorYes<O extends Objectify> extends Transactor<O>
 				throw new IllegalStateException("MANDATORY transaction but no transaction present");
 
 			case REQUIRES_NEW:
-				return transactNew(parent, Integer.MAX_VALUE, work);
+				return transactNew(parent, DEFAULT_TRY_LIMIT, work);
 
 			default:
 				throw new IllegalStateException("Impossible, some unknown txn type");


### PR DESCRIPTION
When we try to save the entity in a transaction we are getting a lot of datastore contention exception.
We can reduce their number by randomly suspending a given thread for a while and retrying it a little bit later.
As I have seen in there was implemented a solution for it on the master.
Based on that created the same into Objectify v5.

I have added a small improvement:
Let the caller handle ConcurrentModificationException when we got InterruptedException in exponential backoff. 
