### PR TITLE
fix(v5): Avoid raising exceptions due to unreachable memcache

### DIFF
--- a/src/main/java/com/googlecode/objectify/cache/CachingAsyncDatastoreService.java
+++ b/src/main/java/com/googlecode/objectify/cache/CachingAsyncDatastoreService.java
@@ -275,8 +275,14 @@ public class CachingAsyncDatastoreService implements AsyncDatastoreService
 							if (value != null)
 								buck.setNext(value);
 						}
-						
-						memcache.putAll(uncached);
+						try{
+							memcache.putAll(uncached);
+						} catch(Exception ex){
+							// It is possible that memcache is unreachable. Continue if
+							// this happens as data was retrieved from datastore and
+							// will result in a cache miss on next access where we
+							// can try to cache again.
+						}
 					}
 				};
 			}

--- a/src/main/java/com/googlecode/objectify/cache/EntityMemcache.java
+++ b/src/main/java/com/googlecode/objectify/cache/EntityMemcache.java
@@ -247,10 +247,11 @@ public class EntityMemcache
 
 		if (!cold.isEmpty())
 		{
-			// The cache is cold for those values, so start them out with nulls that we can make an IV for
-			this.memcache.putAll(cold);
-
 			try {
+			   // The cache is cold for those values, so start them out with nulls that we can make an IV for
+			   // It is possible that memcache is unreachable, catch that failure.
+			   this.memcache.putAll(cold);
+
 				Map<Key, IdentifiableValue> ivs2 = this.memcache.getIdentifiables(cold.keySet());
 				ivs.putAll(ivs2);
 			} catch (Exception ex) {


### PR DESCRIPTION
Proposed solution to #466

Surrounds calls to `memcache.putall` and continues.