### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
+				<configuration>
+					<parallel>all</parallel>
+				</configuration>
+
 			</plugin>
 
 			<plugin>
@@ -168,12 +172,7 @@
 
 	<dependencies>
 		<!-- Used for build only. You'll need the lombok plugin in your IDE. -->
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.10</version>
-			<scope>provided</scope>
-		</dependency>
+		
 
 		<dependency>
 			<groupId>com.google.cloud</groupId>
@@ -237,12 +236,7 @@
 			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
+		
 
 		<dependency>
 			<groupId>com.google.truth</groupId>
@@ -258,12 +252,7 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<version>${slf4j.version}</version>
-			<scope>test</scope>
-		</dependency>
+		
 	</dependencies>
 
 </project>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
objectify
{groupId='org.projectlombok', artifactId='lombok'}
{groupId='org.junit.jupiter', artifactId='junit-jupiter-engine'}
{groupId='org.slf4j', artifactId='slf4j-jdk14'}


According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
