### PR TITLE
With GraalVM native, some code will box null into 0 and introduce defects

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/FieldProperty.java
+++ b/src/main/java/com/googlecode/objectify/impl/FieldProperty.java
@@ -85,8 +85,9 @@ public class FieldProperty extends AbstractProperty
 	@Override
 	public Object get(Object pojo) {
 		try {
-			//return this.field.get(pojo);
-			return getter.invoke(pojo);
+			return this.field.get(pojo);
+			// With GraalVM native, the code below will box null into 0 and introduce wrong behavior
+			// return getter.invoke(pojo);
 		}
 		catch (RuntimeException ex) { throw ex; }
 		catch (Throwable ex) { throw new RuntimeException(ex); }


### PR DESCRIPTION
Trying to support GraalVM native for my project, came across this issue:
https://github.com/oracle/graal/issues/5672
The change in this pull request (going back to original code flow) seems to solve the issue.
Is there anything wrong with using the old code?