### PR TITLE
fix: Correctly load a `null` embedded map value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.18</version>
+			<version>1.18.30</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/com/googlecode/objectify/impl/WriteEngine.java
+++ b/src/main/java/com/googlecode/objectify/impl/WriteEngine.java
@@ -68,6 +68,8 @@ public class WriteEngine
 				final EntityMetadata<E> metadata = factory().getMetadataForEntity(obj);
 				final FullEntity<?> translated = metadata.save(obj, ctx);
 				entityList.add(translated);
+				System.out.println("Input POJO = " + obj);
+				System.out.println("Translated Entity = " + translated);
 			}
 		}
 

--- a/src/main/java/com/googlecode/objectify/impl/translate/CollectionTranslatorFactory.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/CollectionTranslatorFactory.java
@@ -44,11 +44,6 @@ public class CollectionTranslatorFactory implements TranslatorFactory<Collection
 
 			@Override
 			public Collection<Object> loadInto(final Value<List<? extends Value<?>>> node, final LoadContext ctx, final Path path, Collection<Object> collection) throws SkipException {
-				// If the collection does not exist, skip it entirely. This mirrors the OLD underlying behavior
-				// of collections in the datastore; if they are empty, they don't exist.
-				if (node == null)
-					throw new SkipException();
-
 				if (collection == null)
 					//noinspection unchecked
 					collection = (Collection<Object>)fact.constructCollection(collectionType, node.get().size());

--- a/src/main/java/com/googlecode/objectify/impl/translate/EmbeddedMapTranslatorFactory.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/EmbeddedMapTranslatorFactory.java
@@ -70,10 +70,6 @@ public class EmbeddedMapTranslatorFactory implements TranslatorFactory<Map<Objec
 
 			@Override
 			public Map<Object, Object> loadInto(final Value<FullEntity<?>> node, final LoadContext ctx, final Path path, Map<Object, Object> into) {
-				// Make this work more like collections than atomic values
-				if (node == null)
-					throw new SkipException();
-
 				if (into == null)
 					//noinspection unchecked
 					into = (Map<Object, Object>)fact.constructMap(mapType);

--- a/src/main/java/com/googlecode/objectify/impl/translate/TranslatorRecycles.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/TranslatorRecycles.java
@@ -1,6 +1,7 @@
 package com.googlecode.objectify.impl.translate;
 
 import com.google.cloud.datastore.Value;
+import com.google.cloud.datastore.ValueType;
 import com.googlecode.objectify.impl.Path;
 
 /**
@@ -13,6 +14,18 @@ import com.googlecode.objectify.impl.Path;
 abstract public class TranslatorRecycles<P, D> implements Translator<P, D>, Recycles {
 	@Override
 	final public P load(final Value<D> node, final LoadContext ctx, final Path path) throws SkipException {
+		// If the underlying container (Map, EmbeddedMap or Collection) does not exist, skip it entirely.
+		// For Collections, this mirrors the OLD underlying behavior of collections in the datastore;
+		// if they are empty, they don't exist.
+		if (node == null) {
+			throw new SkipException();
+		}
+
+		// If the container value type is `NULL`, the value the POJO is simply `null`.
+		if (node.getType() == ValueType.NULL) {
+			return null;
+		}
+
 		@SuppressWarnings("unchecked")
 		final P into = (P)ctx.useRecycled();
 

--- a/src/test/java/com/googlecode/objectify/test/EmbeddedNullContainerTests.java
+++ b/src/test/java/com/googlecode/objectify/test/EmbeddedNullContainerTests.java
@@ -1,0 +1,2 @@
+package com.googlecode.objectify.test;public class EmbeddedNullContainerTests {
+}

--- a/src/test/java/com/googlecode/objectify/test/EmbeddedNullContainerTests.java
+++ b/src/test/java/com/googlecode/objectify/test/EmbeddedNullContainerTests.java
@@ -1,2 +1,69 @@
-package com.googlecode.objectify.test;public class EmbeddedNullContainerTests {
+package com.googlecode.objectify.test;
+
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.test.util.TestBase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.googlecode.objectify.ObjectifyService.factory;
+
+public class EmbeddedNullContainerTests extends TestBase {
+
+  @Test
+  void testLoadingEmbeddedMapNullValue() {
+    factory().register(Sample.class);
+
+    List<Value> valueList = new ArrayList<>();
+    valueList.add(new Value(null, null));
+
+    Map<String, List<Value>> values = new HashMap<String, List<Value>>();
+    values.put("k1", valueList);
+
+    final Sample sample = new Sample("testKey", values);
+    final Sample retrieved  = saveClearLoad(sample);
+
+    assertThat(sample.values).isEqualTo(retrieved.values);
+  }
+
+
+  @Test
+  void testLoadingNullListValue() {
+    factory().register(Sample.class);
+
+    Map<String, List<Value>> values = new HashMap<String, List<Value>>();
+    values.put("k1", null);
+
+    final Sample sample = new Sample("testKey", values);
+    final Sample retrieved  = saveClearLoad(sample);
+    
+    assertThat(sample.values).isEqualTo(retrieved.values);
+  }
+
+
+  @Entity(name = "Sample")
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Sample {
+    @Id
+    String name;
+    Map<String, List<Value>> values;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Value {
+    String primitiveField;
+    Map<String, String> structuredField;
+  }
 }


### PR DESCRIPTION
 fix: This change fixes the `null` value handling for containers like Maps, EmbeddedMaps and Collections when loading data from native Entity format to POJOs
        - For other value types, the Translator is derived from NullSafeTranslator which checks for `null` values before allocating a value object for the POJO.
        - For Translator classes not using NullSafeTranslator, the check for `null` to short-circuit the `load` method to return `null` and avoid trying to load properties of values with ValueType.NULL (which will lead to NPE).

        Tested:
        - manually End-to-End using the repro steps
        - unit test