### PR TITLE
fix: Correctly load a null embedded map and collection value 

### DIFF
--- a/src/main/java/com/googlecode/objectify/impl/translate/CollectionTranslatorFactory.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/CollectionTranslatorFactory.java
@@ -44,11 +44,6 @@ public class CollectionTranslatorFactory implements TranslatorFactory<Collection
 
 			@Override
 			public Collection<Object> loadInto(final Value<List<? extends Value<?>>> node, final LoadContext ctx, final Path path, Collection<Object> collection) throws SkipException {
-				// If the collection does not exist, skip it entirely. This mirrors the OLD underlying behavior
-				// of collections in the datastore; if they are empty, they don't exist.
-				if (node == null || node.get() == null)
-					throw new SkipException();
-
 				if (collection == null)
 					//noinspection unchecked
 					collection = (Collection<Object>)fact.constructCollection(collectionType, node.get().size());

--- a/src/main/java/com/googlecode/objectify/impl/translate/EmbeddedMapTranslatorFactory.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/EmbeddedMapTranslatorFactory.java
@@ -70,10 +70,6 @@ public class EmbeddedMapTranslatorFactory implements TranslatorFactory<Map<Objec
 
 			@Override
 			public Map<Object, Object> loadInto(final Value<FullEntity<?>> node, final LoadContext ctx, final Path path, Map<Object, Object> into) {
-				// Make this work more like collections than atomic values
-				if (node == null)
-					throw new SkipException();
-
 				if (into == null)
 					//noinspection unchecked
 					into = (Map<Object, Object>)fact.constructMap(mapType);

--- a/src/main/java/com/googlecode/objectify/impl/translate/TranslatorRecycles.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/TranslatorRecycles.java
@@ -1,6 +1,7 @@
 package com.googlecode.objectify.impl.translate;
 
 import com.google.cloud.datastore.Value;
+import com.google.cloud.datastore.ValueType;
 import com.googlecode.objectify.impl.Path;
 
 /**
@@ -13,6 +14,18 @@ import com.googlecode.objectify.impl.Path;
 abstract public class TranslatorRecycles<P, D> implements Translator<P, D>, Recycles {
 	@Override
 	final public P load(final Value<D> node, final LoadContext ctx, final Path path) throws SkipException {
+		// If the underlying container (Map, EmbeddedMap or Collection) does not exist, skip it entirely.
+		// For Collections, this mirrors the OLD underlying behavior of collections in the datastore;
+		// if they are empty, they don't exist.
+		if (node == null) {
+			throw new SkipException();
+		}
+
+		// If the container value type is `NULL`, the value the POJO is simply `null`.
+		if (node.getType() == ValueType.NULL) {
+			return null;
+		}
+
 		@SuppressWarnings("unchecked")
 		final P into = (P)ctx.useRecycled();
 

--- a/src/test/java/com/googlecode/objectify/test/EmbeddedNullContainerTests.java
+++ b/src/test/java/com/googlecode/objectify/test/EmbeddedNullContainerTests.java
@@ -1,0 +1,2 @@
+package com.googlecode.objectify.test;public class EmbeddedNullContainerTests {
+}


### PR DESCRIPTION
… Maps, EmbeddedMaps and Collections when loading data from native Entity format to POJOs

    - For other value types, the Translator is derived from NullSafeTranslator which checks for `null` values before allocating a value object for the POJO.
    - Fixed the CollectionTranslatorFactory.java to return `null` instead of `throw SkipException()` when the `node` is `null`.
    - For Translator classes not using NullSafeTranslator, the check for `null` to short-circuit the `load` method to return `null` and avoid trying to load properties of values with ValueType.NULL (which will lead to NPE).

    Tested:
    - using App.java test (code below)

NOTE: before running the test, I also added the following docs from the console:

For `sample2`, 
```{
  "properties": {
    "k1": {
      "arrayValue": {
        "values": [
          {
            "entityValue": {
              "properties": {
                "primitiveField": {
                  "nullValue": null,
                  "excludeFromIndexes": true
                },
                "structuredField": {
                  "nullValue": null,
                  "excludeFromIndexes": true
                }
              }
            }
          }
        ]
      }
    }
  }
}
```

For `sample4`, 
```
{
  "properties": {
    "k1": {
      "nullValue": null
    }
  }
}
```

// Code for App.java:
```
package com.googlecode.objectify.test.integration;

import static org.junit.Assert.assertEquals;

import com.google.cloud.datastore.DatastoreOptions;
import com.googlecode.objectify.Key;
import com.googlecode.objectify.ObjectifyFactory;
import com.googlecode.objectify.ObjectifyService;
import com.googlecode.objectify.annotation.Entity;
import com.googlecode.objectify.annotation.Id;
import com.googlecode.objectify.util.Closeable;
import java.io.PrintWriter;
import java.io.StringWriter;
import java.util.ArrayList;
import java.util.HashMap;
import java.util.List;
import java.util.Map;
import lombok.AllArgsConstructor;
import lombok.Data;
import lombok.NoArgsConstructor;

public class App {

  @Entity(name = "Sample")
  @Data
  @NoArgsConstructor
  @AllArgsConstructor
  public static class Sample {
    @Id String name;
    Map<String, List<Value>> values;
  }

  @Data
  @NoArgsConstructor
  @AllArgsConstructor
  public static class Value {
    String primitiveField;
    Map<String, String> structuredField;
  }

  public static void testLoadingNullEmbeddedMapValueUsingObjectifyV6() {
    List<Value> valueList = new ArrayList<>();
    valueList.add(new Value(null, null));

    Map<String, List<Value>> values = new HashMap<String, List<Value>>();
    values.put("k1", valueList);

    String appDocName = "sample1"; // entered from app
    String consoleDocName = "sample2"; // entered from console, both null
    //Sample consoleDocSample = new Sample(consoleDocName, values);
    Sample appDocSample = new Sample(appDocName, values);

    DatastoreOptions datastoreOptions = DatastoreOptions.newBuilder()
        .setProjectId("jimit-test")
        .setNamespace("objectify-test")
        .build();
    ObjectifyFactory factory = new ObjectifyFactory(datastoreOptions.getService());
    factory.register(Sample.class);
    ObjectifyService.init(factory);

    try (Closeable ignored = ObjectifyService.begin()) {
      // If an entity is not saved, uncomment the following line and call save() method.
      // And edit the entity directly to `structuredFiled` has null (nullValue) from GCP console
      factory.ofy().save().entity(appDocSample).now();

      Sample appDocEntity = factory.ofy().load().key(Key.create(Sample.class, appDocName)).now();
      Sample consoleDocEntity = factory.ofy().load().key(Key.create(Sample.class, consoleDocName))
          .now();

      System.out.println("appDoc=" + appDocEntity);
      System.out.println("consoleDoc=" + consoleDocEntity);
      assertEquals(appDocEntity, consoleDocEntity);
    } catch (Exception e) {
      StringWriter sw = new StringWriter();
      e.printStackTrace(new PrintWriter(sw));
      System.out.print(sw);
    }
  }


    public static void testLoadingEmbeddedMapNullValue() {
      Map<String, List<Value>> values = new HashMap<>();
      values.put("k1", null);

      String appDocId = "sample3"; // entered from test app
      String consoleDocId = "sample4"; // entered from console, both {k1 = null}
      Sample appDoc = new Sample(appDocId, values);

      DatastoreOptions datastoreOptions = DatastoreOptions.newBuilder()
          .setProjectId("jimit-test")
          .setNamespace("objectify-test")
          .build();
      ObjectifyFactory factory = new ObjectifyFactory(datastoreOptions.getService());
      factory.register(Sample.class);
      ObjectifyService.init(factory);

        try (Closeable ignored = ObjectifyService.begin()) {
          // If an entity is not saved, uncomment the following line and call save() method.
          // And edit the entity directly to `structuredFiled` has null (nullValue) from GCP console
          factory.ofy().save().entity(appDoc).now();

          Sample appDocEntity = factory.ofy().load().key(Key.create(Sample.class, appDocId)).now();
          Sample consoleDocEntity = factory.ofy().load().key(Key.create(Sample.class, consoleDocId)).now();

          System.out.println("appDocEntity=" + appDocEntity.toString());
          System.out.println("consoleDocEntity=" + consoleDocEntity.toString());

          assertEquals(appDocEntity, consoleDocEntity);
        } catch (Exception e) {
             StringWriter sw = new StringWriter();
             e.printStackTrace(new PrintWriter(sw));
             System.out.print(sw);
    }
  }

  public static void main(String[] args) {

    testLoadingNullEmbeddedMapValueUsingObjectifyV6();
    testLoadingEmbeddedMapNullValue();
  }
}
``` 