### PR TITLE
Updating google-cloud-datastore dependency to 2.22.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
 		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-datastore</artifactId>
-			<version>2.17.5</version>
+			<version>2.22.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/test/java/com/googlecode/objectify/test/util/RemoteDatastoreHelper.java
+++ b/src/test/java/com/googlecode/objectify/test/util/RemoteDatastoreHelper.java
@@ -1,0 +1,80 @@
+package com.googlecode.objectify.test.util;
+
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.StructuredQuery;
+import com.google.cloud.http.HttpTransportOptions;
+import java.util.UUID;
+import org.threeten.bp.Duration;
+
+public class RemoteDatastoreHelper {
+  private final DatastoreOptions options;
+  private final Datastore datastore;
+  private final String namespace;
+
+  private RemoteDatastoreHelper(DatastoreOptions options) {
+    this.options = options;
+	this.datastore = options.getService();
+	this.namespace = options.getNamespace();
+  }
+
+  /**
+   * Returns a {@link DatastoreOptions} object to be used for testing. The options are associated to
+   * a randomly generated namespace.
+   */
+  public DatastoreOptions getOptions() {
+	return options;
+  }
+
+  /**
+   * Deletes all entities in the namespace associated with this {@link RemoteDatastoreHelper}.
+   */
+  public void deleteNamespace() {
+	StructuredQuery<Key> query = Query.newKeyQueryBuilder().setNamespace(namespace).build();
+	QueryResults<Key> keys = datastore.run(query);
+	while (keys.hasNext()) {
+	  datastore.delete(keys.next());
+	}
+  }
+
+  /**
+   * Creates a {@code RemoteStorageHelper} object.
+   */
+  public static RemoteDatastoreHelper create() {
+	return create("");
+  }
+
+  /**
+   * Creates a {@code RemoteStorageHelper} object.
+   */
+  public static RemoteDatastoreHelper create(
+	  String databaseId) {
+	HttpTransportOptions transportOptions = DatastoreOptions.getDefaultHttpTransportOptions();
+	transportOptions =
+		transportOptions.toBuilder().setConnectTimeout(60000).setReadTimeout(60000).build();
+	DatastoreOptions.Builder datastoreOptionBuilder =
+		DatastoreOptions.newBuilder()
+            .setDatabaseId(databaseId)
+			.setNamespace(UUID.randomUUID().toString())
+			.setRetrySettings(retrySettings())
+			.setTransportOptions(transportOptions);
+	return new RemoteDatastoreHelper(datastoreOptionBuilder.build());
+  }
+
+  private static RetrySettings retrySettings() {
+	return RetrySettings.newBuilder()
+		.setMaxAttempts(10)
+		.setMaxRetryDelay(Duration.ofMillis(30000L))
+		.setTotalTimeout(Duration.ofMillis(120000L))
+		.setInitialRetryDelay(Duration.ofMillis(250L))
+		.setRetryDelayMultiplier(1.0)
+		.setInitialRpcTimeout(Duration.ofMillis(120000L))
+		.setRpcTimeoutMultiplier(1.0)
+		.setMaxRpcTimeout(Duration.ofMillis(120000L))
+		.build();
+  }
+}

--- a/src/test/java/com/googlecode/objectify/test/util/RemoteObjectifyExtension.java
+++ b/src/test/java/com/googlecode/objectify/test/util/RemoteObjectifyExtension.java
@@ -1,7 +1,6 @@
 package com.googlecode.objectify.test.util;
 
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.testing.RemoteDatastoreHelper;
 import com.google.common.base.Preconditions;
 import com.googlecode.objectify.ObjectifyFactory;
 import com.googlecode.objectify.ObjectifyService;


### PR DESCRIPTION
- Updating `google-cloud-datastore` to enable usage of Datastore [Client-side Tracing feature](https://cloud.google.com/datastore/docs/client-side-traces) recently launched in v2.22.0.
- RemoteDatastoreHelper is marked InternalApi and used exclusively for testing within google-cloud-datatstore.
-  created a local copy of the same for Objectify to use.