### PR TITLE
Provide access to the native Transaction object from AsyncTransaction

### DIFF
--- a/src/main/java/com/googlecode/objectify/cache/CachingAsyncTransaction.java
+++ b/src/main/java/com/googlecode/objectify/cache/CachingAsyncTransaction.java
@@ -6,6 +6,7 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.ReadOption;
+import com.google.cloud.datastore.Transaction;
 import com.google.cloud.datastore.Transaction.Response;
 import com.google.protobuf.ByteString;
 import com.googlecode.objectify.Result;
@@ -125,7 +126,12 @@ public class CachingAsyncTransaction extends CachingAsyncDatastoreReaderWriter i
 	public ByteString getTransactionHandle() {
 		return raw.getTransactionHandle();
 	}
-
+	
+	@Override
+	public Transaction getRawTransaction() {
+		return raw.getRawTransaction();
+	}
+	
 	@Override
 	public void runCommitListeners() {
 		((PrivateAsyncTransaction)raw).runCommitListeners();

--- a/src/main/java/com/googlecode/objectify/impl/AsyncTransaction.java
+++ b/src/main/java/com/googlecode/objectify/impl/AsyncTransaction.java
@@ -1,5 +1,6 @@
 package com.googlecode.objectify.impl;
 
+import com.google.cloud.datastore.Transaction;
 import com.google.cloud.datastore.Transaction.Response;
 import com.google.protobuf.ByteString;
 
@@ -19,4 +20,6 @@ public interface AsyncTransaction extends AsyncDatastoreReaderWriter {
 	void listenForCommit(final Runnable listener);
 
 	ByteString getTransactionHandle();
+	
+	Transaction getRawTransaction();
 }

--- a/src/main/java/com/googlecode/objectify/impl/AsyncTransactionImpl.java
+++ b/src/main/java/com/googlecode/objectify/impl/AsyncTransactionImpl.java
@@ -66,7 +66,12 @@ public class AsyncTransactionImpl extends AsyncDatastoreReaderWriterImpl impleme
 	public ByteString getTransactionHandle() {
 		return transaction.getTransactionId();
 	}
-
+	
+	@Override
+	public Transaction getRawTransaction() {
+		return transaction;
+	}
+	
 	@Override
 	public void runCommitListeners() {
 		for (final Runnable listener : listeners) {


### PR DESCRIPTION
Add `getRawTransaction()` method to `AsyncTransaction` interface and its implementations to expose the underlying `com.google.cloud.datastore.Transaction` object.

  This allows users to access the native Transaction when they need to:
  - Perform operations that require the raw Transaction object
  - Integrate with other libraries or frameworks expecting the native type
  - Access Transaction methods not exposed through the AsyncTransaction wrapper
  - Maintaining API parity for users migrating from earlier versions