### PR TITLE
Add Valkey 9.0 MemcacheService backed by valkey-glide

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.valkey</groupId>
+			<artifactId>valkey-glide</artifactId>
+			<version>2.3.1</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
@@ -278,6 +285,19 @@
 			<groupId>io.opentelemetry</groupId>
 			<artifactId>opentelemetry-exporter-jaeger</artifactId>
 			<version>1.34.1</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>1.20.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>1.20.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
+++ b/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
@@ -1,0 +1,233 @@
+package com.googlecode.objectify.cache.valkey;
+
+import com.googlecode.objectify.cache.IdentifiableValue;
+import com.googlecode.objectify.cache.MemcacheService;
+import glide.api.GlideClient;
+import glide.api.models.GlideString;
+import glide.api.models.commands.SetOptions;
+import glide.api.models.commands.SetOptions.ConditionalSet;
+import lombok.RequiredArgsConstructor;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static glide.api.models.GlideString.gs;
+
+/**
+ * A {@link MemcacheService} backed by Valkey 9.0+ using the valkey-glide client.
+ *
+ * <p>Compare-and-swap is implemented with the native {@code SET key value IFEQ comparison-value}
+ * command introduced in Valkey 8.1 (and rounded out in 9.0 with companion commands like
+ * {@code DELIFEQ}). This is one round trip per key, versus the multi-step
+ * {@code WATCH/GET/MULTI/SET/EXEC} dance required on older Redis-compatible servers.</p>
+ *
+ * <p>Cold-cache handling: {@code IFEQ} requires the key to exist with the comparison value, so on
+ * a miss {@link #getIdentifiables} bootstraps a single-byte null sentinel via {@code SET NX} and
+ * then re-reads the key. The bootstrap value is what subsequent {@link #putIfUntouched} calls
+ * compare against, mirroring the {@code add}-then-{@code gets} pattern used for memcached.</p>
+ *
+ * <p>Null values are stored as a single {@code 0x00} byte. Java-serialized objects always begin
+ * with the magic bytes {@code 0xAC 0xED}, so the sentinel can never collide with a real value.</p>
+ */
+@RequiredArgsConstructor
+public class ValkeyCacheService implements MemcacheService {
+
+	/** Single-byte sentinel for null. Cannot collide with Java-serialized data (which starts 0xAC 0xED). */
+	private static final byte[] NULL_VALUE = new byte[]{0};
+
+	/** "OK" reply from Valkey when a write succeeds. */
+	private static final String OK = "OK";
+
+	private final GlideClient client;
+
+	private static byte[] toCacheBytes(final Object thing) {
+		if (thing == null) {
+			return NULL_VALUE;
+		}
+		try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			 final ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+			oos.writeObject(thing);
+			oos.flush();
+			return baos.toByteArray();
+		} catch (final IOException e) {
+			throw new RuntimeException("Failed to serialize cache value", e);
+		}
+	}
+
+	private static Object fromCacheBytes(final byte[] bytes) {
+		if (bytes == null || Arrays.equals(bytes, NULL_VALUE)) {
+			return null;
+		}
+		try (final ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+			 final ObjectInputStream ois = new ObjectInputStream(bais)) {
+			return ois.readObject();
+		} catch (final IOException | ClassNotFoundException e) {
+			throw new RuntimeException("Failed to deserialize cache value", e);
+		}
+	}
+
+	private static GlideString gskey(final String key) {
+		return gs(key.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static <T> T await(final java.util.concurrent.CompletableFuture<T> future) {
+		try {
+			return future.get();
+		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		} catch (final ExecutionException e) {
+			throw new RuntimeException(e.getCause());
+		}
+	}
+
+	private byte[] rawGet(final String key) {
+		final GlideString result = await(client.get(gskey(key)));
+		return result == null ? null : result.getBytes();
+	}
+
+	@Override
+	public Object get(final String key) {
+		return fromCacheBytes(rawGet(key));
+	}
+
+	@Override
+	public Map<String, IdentifiableValue> getIdentifiables(final Collection<String> keys) {
+		final Map<String, IdentifiableValue> result = new LinkedHashMap<>();
+		for (final String key : keys) {
+			result.put(key, getIdentifiable(key));
+		}
+		return result;
+	}
+
+	private IdentifiableValue getIdentifiable(final String key) {
+		final byte[] bytes = rawGet(key);
+		if (bytes != null) {
+			return new ValkeyIdentifiableValue(fromCacheBytes(bytes), bytes);
+		}
+
+		// Cold cache: bootstrap a sentinel under NX so we can later CAS against it. NX prevents
+		// us from clobbering a value another caller has just set in between our GET and our SET.
+		final SetOptions nx = SetOptions.builder()
+				.conditionalSet(ConditionalSet.ONLY_IF_DOES_NOT_EXIST)
+				.build();
+		await(client.set(gskey(key), gs(NULL_VALUE), nx));
+
+		final byte[] bootstrapped = rawGet(key);
+		return bootstrapped == null ? null : new ValkeyIdentifiableValue(fromCacheBytes(bootstrapped), bootstrapped);
+	}
+
+	@Override
+	public Map<String, Object> getAll(final Collection<String> keys) {
+		final Map<String, Object> result = new LinkedHashMap<>();
+		if (keys.isEmpty()) {
+			return result;
+		}
+
+		final GlideString[] keyArray = keys.stream()
+				.map(ValkeyCacheService::gskey)
+				.toArray(GlideString[]::new);
+
+		final Object[] values = await(client.mget(keyArray));
+
+		int i = 0;
+		for (final String key : keys) {
+			final Object raw = values[i++];
+			if (raw != null) {
+				result.put(key, fromCacheBytes(((GlideString) raw).getBytes()));
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public void put(final String key, final Object thing) {
+		await(client.set(gskey(key), gs(toCacheBytes(thing))));
+	}
+
+	@Override
+	public void putAll(final Map<String, Object> values) {
+		if (values.isEmpty()) {
+			return;
+		}
+		final Map<GlideString, GlideString> mapping = new LinkedHashMap<>();
+		values.forEach((key, value) -> mapping.put(gskey(key), gs(toCacheBytes(value))));
+		await(client.msetBinary(mapping));
+	}
+
+	/**
+	 * Atomically writes new values only when the existing bytes still match the snapshot taken
+	 * at {@link #getIdentifiables} time. Each key issues a single
+	 * {@code SET key value IFEQ comparison-value [EX seconds]} command; Valkey performs the
+	 * comparison server-side and either commits the write (returning {@code "OK"}) or aborts
+	 * (returning {@code nil}).
+	 */
+	@Override
+	public Set<String> putIfUntouched(final Map<String, CasPut> values) {
+		final Set<String> successes = new HashSet<>();
+
+		for (final Map.Entry<String, CasPut> entry : values.entrySet()) {
+			final String key = entry.getKey();
+			final CasPut casPut = entry.getValue();
+			final ValkeyIdentifiableValue viv = (ValkeyIdentifiableValue) casPut.getIv();
+
+			final byte[] expected = viv.getRawBytes();
+			final byte[] next = toCacheBytes(casPut.getNextToStore());
+			final int ttl = casPut.getExpirationSeconds();
+
+			final GlideString[] args = ttl > 0
+					? new GlideString[]{
+							gs("SET"), gskey(key), gs(next),
+							gs("IFEQ"), gs(expected),
+							gs("EX"), gs(Integer.toString(ttl))}
+					: new GlideString[]{
+							gs("SET"), gskey(key), gs(next),
+							gs("IFEQ"), gs(expected)};
+
+			final Object response = await(client.customCommand(args));
+			if (isOk(response)) {
+				successes.add(key);
+			}
+		}
+
+		return successes;
+	}
+
+	private static boolean isOk(final Object response) {
+		if (response == null) {
+			return false;
+		}
+		if (response instanceof String) {
+			return OK.equals(response);
+		}
+		if (response instanceof GlideString) {
+			return OK.equals(((GlideString) response).getString());
+		}
+		if (response instanceof byte[]) {
+			return Arrays.equals(OK.getBytes(StandardCharsets.UTF_8), (byte[]) response);
+		}
+		return false;
+	}
+
+	@Override
+	public void deleteAll(final Collection<String> keys) {
+		if (keys.isEmpty()) {
+			return;
+		}
+		final GlideString[] keyArray = keys.stream()
+				.map(ValkeyCacheService::gskey)
+				.toArray(GlideString[]::new);
+		await(client.del(keyArray));
+	}
+}

--- a/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyIdentifiableValue.java
+++ b/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyIdentifiableValue.java
@@ -1,0 +1,21 @@
+package com.googlecode.objectify.cache.valkey;
+
+import com.googlecode.objectify.cache.IdentifiableValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * CAS handle for {@link ValkeyCacheService}. Wraps the deserialized value alongside the raw bytes
+ * read from Valkey, which are later passed to {@code SET ... IFEQ comparison-value} so the server
+ * can atomically reject the write when another client has changed the key in the meantime.
+ */
+@RequiredArgsConstructor
+public class ValkeyIdentifiableValue implements IdentifiableValue {
+
+	@Getter
+	private final Object value;
+
+	/** Raw bytes that were stored at the time of the read; used as the IFEQ comparison value. */
+	@Getter
+	private final byte[] rawBytes;
+}

--- a/src/test/java/com/googlecode/objectify/test/util/valkey/LocalValkeyExtension.java
+++ b/src/test/java/com/googlecode/objectify/test/util/valkey/LocalValkeyExtension.java
@@ -1,0 +1,59 @@
+package com.googlecode.objectify.test.util.valkey;
+
+import glide.api.GlideClient;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Boots a Valkey 9.0 container once per JVM and exposes a {@link GlideClient} that connects
+ * to it. {@code FLUSHALL} runs before each test so cached state from prior tests cannot leak.
+ */
+@Slf4j
+public class LocalValkeyExtension implements BeforeAllCallback, BeforeEachCallback {
+
+	private static final DockerImageName IMAGE = DockerImageName.parse("valkey/valkey:9.0");
+
+	@Override
+	public void beforeAll(final ExtensionContext context) throws Exception {
+		if (getClient(context) != null) {
+			return;
+		}
+
+		log.info("Starting Valkey container");
+
+		@SuppressWarnings("resource")
+		final GenericContainer<?> container = new GenericContainer<>(IMAGE).withExposedPorts(6379);
+		container.start();
+
+		final GlideClient client = GlideClient.createClient(
+				GlideClientConfiguration.builder()
+						.address(NodeAddress.builder()
+								.host(container.getHost())
+								.port(container.getMappedPort(6379))
+								.build())
+						.requestTimeout(5000)
+						.build()
+		).get();
+
+		final Namespace ns = Namespace.GLOBAL;
+		context.getRoot().getStore(ns).put(GenericContainer.class, container);
+		context.getRoot().getStore(ns).put(GlideClient.class, client);
+	}
+
+	@Override
+	public void beforeEach(final ExtensionContext context) throws Exception {
+		final GlideClient client = getClient(context);
+		client.customCommand(new String[]{"FLUSHALL"}).get();
+	}
+
+	public static GlideClient getClient(final ExtensionContext context) {
+		return context.getRoot().getStore(Namespace.GLOBAL).get(GlideClient.class, GlideClient.class);
+	}
+}

--- a/src/test/java/com/googlecode/objectify/test/util/valkey/ValkeyObjectifyExtension.java
+++ b/src/test/java/com/googlecode/objectify/test/util/valkey/ValkeyObjectifyExtension.java
@@ -1,0 +1,47 @@
+package com.googlecode.objectify.test.util.valkey;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.google.common.base.Preconditions;
+import com.googlecode.objectify.ObjectifyFactory;
+import com.googlecode.objectify.ObjectifyService;
+import com.googlecode.objectify.cache.valkey.ValkeyCacheService;
+import com.googlecode.objectify.test.util.LocalDatastoreExtension;
+import com.googlecode.objectify.util.Closeable;
+import glide.api.GlideClient;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+
+/**
+ * Equivalent of {@link com.googlecode.objectify.test.util.ObjectifyExtension} that wires the
+ * factory with a {@link ValkeyCacheService} instead of the spymemcached-backed service.
+ */
+public class ValkeyObjectifyExtension implements BeforeEachCallback, AfterEachCallback {
+
+	private static final Namespace NAMESPACE = Namespace.create(ValkeyObjectifyExtension.class);
+
+	@Override
+	public void beforeEach(final ExtensionContext context) throws Exception {
+		final LocalDatastoreHelper helper = LocalDatastoreExtension.getHelper(context);
+		Preconditions.checkNotNull(helper, "This extension depends on " + LocalDatastoreExtension.class.getSimpleName());
+
+		final Datastore datastore = helper.getOptions().getService();
+
+		final GlideClient client = LocalValkeyExtension.getClient(context);
+		Preconditions.checkNotNull(client, "This extension depends on " + LocalValkeyExtension.class.getSimpleName());
+
+		ObjectifyService.init(new ObjectifyFactory(datastore, new ValkeyCacheService(client)));
+
+		final Closeable rootService = ObjectifyService.begin();
+
+		context.getStore(NAMESPACE).put(Closeable.class, rootService);
+	}
+
+	@Override
+	public void afterEach(final ExtensionContext context) throws Exception {
+		final Closeable rootService = context.getStore(NAMESPACE).get(Closeable.class, Closeable.class);
+		rootService.close();
+	}
+}

--- a/src/test/java/com/googlecode/objectify/test/util/valkey/ValkeyTestBase.java
+++ b/src/test/java/com/googlecode/objectify/test/util/valkey/ValkeyTestBase.java
@@ -1,0 +1,60 @@
+package com.googlecode.objectify.test.util.valkey;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.EntityValue;
+import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.IncompleteKey;
+import com.google.cloud.datastore.Value;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.cache.MemcacheService;
+import com.googlecode.objectify.impl.AsyncDatastore;
+import com.googlecode.objectify.test.util.LocalDatastoreExtension;
+import com.googlecode.objectify.test.util.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.googlecode.objectify.ObjectifyService.factory;
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+/**
+ * Mirror of {@link com.googlecode.objectify.test.util.TestBase} that wires the cache layer with
+ * the Valkey-backed {@link com.googlecode.objectify.cache.valkey.ValkeyCacheService} instead of
+ * spymemcached.
+ */
+@ExtendWith({
+		MockitoExtension.class,
+		LocalDatastoreExtension.class,
+		LocalValkeyExtension.class,
+		ValkeyObjectifyExtension.class,
+})
+public class ValkeyTestBase {
+	protected Value<FullEntity<?>> makeEmbeddedEntityWithProperty(final String name, final Value<?> value) {
+		return EntityValue.of(FullEntity.newBuilder().set(name, value).build());
+	}
+
+	protected Datastore datastore() {
+		return factory().datastore();
+	}
+
+	protected MemcacheService memcache() {
+		return factory().memcache();
+	}
+
+	protected AsyncDatastore asyncDatastore() {
+		return factory().asyncDatastore();
+	}
+
+	protected <E> E saveClearLoad(final E thing) {
+		final Key<E> key = ofy().save().entity(thing).now();
+		ofy().clear();
+		return ofy().load().key(key).now();
+	}
+
+	protected FullEntity.Builder<?> makeEntity(final Class<?> kind) {
+		return makeEntity(Key.getKind(kind));
+	}
+
+	protected FullEntity.Builder<?> makeEntity(final String kind) {
+		final IncompleteKey incompleteKey = factory().datastore().newKeyFactory().setKind(kind).newKey();
+		return FullEntity.newBuilder(incompleteKey);
+	}
+}

--- a/src/test/java/com/googlecode/objectify/test/valkey/ValkeyBasicCacheTests.java
+++ b/src/test/java/com/googlecode/objectify/test/valkey/ValkeyBasicCacheTests.java
@@ -1,0 +1,107 @@
+package com.googlecode.objectify.test.valkey;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.ObjectifyFactory;
+import com.googlecode.objectify.ObjectifyService;
+import com.googlecode.objectify.cache.MemcacheService;
+import com.googlecode.objectify.cache.valkey.ValkeyCacheService;
+import com.googlecode.objectify.impl.AsyncDatastore;
+import com.googlecode.objectify.test.entity.Trivial;
+import com.googlecode.objectify.util.Closeable;
+import glide.api.GlideClient;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.googlecode.objectify.ObjectifyService.factory;
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+/**
+ * Mirrors {@link com.googlecode.objectify.test.BasicCacheTests} but boots its own Valkey container
+ * and {@link GlideClient} so it can wire a custom {@link ObjectifyFactory} subclass — the same
+ * pattern the memcached version uses to assert the global-cache flag is honored.
+ */
+class ValkeyBasicCacheTests {
+
+	private static class NeverAllowCacheFactory extends ObjectifyFactory {
+		NeverAllowCacheFactory(final Datastore datastore, final MemcacheService memcache) {
+			super(datastore, memcache);
+		}
+
+		@Override
+		public AsyncDatastore asyncDatastore(final boolean enableGlobalCache) {
+			assertThat(enableGlobalCache).isFalse();
+			return super.asyncDatastore(enableGlobalCache);
+		}
+	}
+
+	@SuppressWarnings("resource")
+	private static final GenericContainer<?> VALKEY = new GenericContainer<>(DockerImageName.parse("valkey/valkey:9.0"))
+			.withExposedPorts(6379);
+
+	private static GlideClient client;
+	private Closeable rootService;
+
+	@BeforeAll
+	static void startValkey() throws Exception {
+		VALKEY.start();
+		client = GlideClient.createClient(
+				GlideClientConfiguration.builder()
+						.address(NodeAddress.builder().host(VALKEY.getHost()).port(VALKEY.getMappedPort(6379)).build())
+						.requestTimeout(5000)
+						.build()
+		).get();
+	}
+
+	@AfterAll
+	static void stopValkey() throws Exception {
+		if (client != null) {
+			client.close();
+		}
+		VALKEY.stop();
+	}
+
+	@BeforeEach
+	void setUp() throws IOException, InterruptedException {
+		client.customCommand(new String[]{"FLUSHALL"});
+
+		final LocalDatastoreHelper helper = LocalDatastoreHelper.create(1.0);
+		helper.start();
+		final Datastore datastore = helper.getOptions().getService();
+
+		ObjectifyService.init(new NeverAllowCacheFactory(datastore, new ValkeyCacheService(client)));
+
+		rootService = ObjectifyService.begin();
+	}
+
+	@AfterEach
+	void tearDown() {
+		rootService.close();
+	}
+
+	@Test
+	void cacheOptionWorks() throws Exception {
+		factory().register(Trivial.class);
+
+		final Trivial triv = new Trivial("foo", 5);
+		final Key<Trivial> k = ofy().cache(false).save().entity(triv).now();
+
+		final Trivial fetched = ofy().cache(false).load().key(k).now();
+		assertThat(fetched.getId()).isEqualTo(k.getId());
+
+		ofy().clear();
+		final Trivial fetched2 = ofy().cache(false).load().key(k).now();
+		assertThat(fetched2.getId()).isEqualTo(k.getId());
+	}
+}

--- a/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCacheServiceTests.java
+++ b/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCacheServiceTests.java
@@ -1,0 +1,264 @@
+package com.googlecode.objectify.test.valkey;
+
+import com.googlecode.objectify.cache.IdentifiableValue;
+import com.googlecode.objectify.cache.MemcacheService;
+import com.googlecode.objectify.cache.MemcacheService.CasPut;
+import com.googlecode.objectify.cache.valkey.ValkeyCacheService;
+import com.googlecode.objectify.cache.valkey.ValkeyIdentifiableValue;
+import glide.api.GlideClient;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Direct unit tests for {@link ValkeyCacheService}, covering the behavior the higher-level
+ * {@code EntityMemcache}-driven tests don't exercise: the null sentinel on cold-cache reads,
+ * the {@code SET ... IFEQ} CAS contract for both winners and losers, native {@code EX seconds}
+ * expiration, and a multi-threaded race where only one CAS may win.
+ */
+class ValkeyCacheServiceTests {
+
+	@SuppressWarnings("resource")
+	private static final GenericContainer<?> VALKEY = new GenericContainer<>(DockerImageName.parse("valkey/valkey:9.0"))
+			.withExposedPorts(6379);
+
+	private static GlideClient client;
+	private MemcacheService cache;
+
+	@BeforeAll
+	static void startValkey() throws Exception {
+		VALKEY.start();
+		client = GlideClient.createClient(
+				GlideClientConfiguration.builder()
+						.address(NodeAddress.builder().host(VALKEY.getHost()).port(VALKEY.getMappedPort(6379)).build())
+						.requestTimeout(5000)
+						.build()
+		).get();
+	}
+
+	@AfterAll
+	static void stopValkey() throws Exception {
+		if (client != null) {
+			client.close();
+		}
+		VALKEY.stop();
+	}
+
+	@BeforeEach
+	void flush() throws Exception {
+		client.customCommand(new String[]{"FLUSHALL"}).get();
+		cache = new ValkeyCacheService(client);
+	}
+
+	@Test
+	void putAndGetRoundTripsArbitrarySerializable() {
+		final Sample value = new Sample("hello", 42);
+		cache.put("k", value);
+		assertThat(cache.get("k")).isEqualTo(value);
+	}
+
+	@Test
+	void getAbsentKeyReturnsNull() {
+		assertThat(cache.get("nope")).isNull();
+	}
+
+	@Test
+	void putNullStoresAndReadsBackAsNull() {
+		cache.put("k", null);
+		assertThat(cache.get("k")).isNull();
+	}
+
+	@Test
+	void getAllSkipsAbsentKeys() {
+		cache.put("a", "alpha");
+		cache.put("c", "gamma");
+
+		final Map<String, Object> result = cache.getAll(Arrays.asList("a", "b", "c"));
+		assertThat(result).containsExactly("a", "alpha", "c", "gamma");
+	}
+
+	@Test
+	void putAllWritesEverything() {
+		final Map<String, Object> in = new LinkedHashMap<>();
+		in.put("a", "alpha");
+		in.put("b", null);
+		cache.putAll(in);
+
+		assertThat(cache.get("a")).isEqualTo("alpha");
+		assertThat(cache.get("b")).isNull();
+	}
+
+	@Test
+	void deleteAllRemovesKeys() {
+		cache.put("a", "alpha");
+		cache.put("b", "beta");
+		cache.deleteAll(Arrays.asList("a", "b"));
+		assertThat(cache.get("a")).isNull();
+		assertThat(cache.get("b")).isNull();
+	}
+
+	@Test
+	void getIdentifiablesBootstrapsColdCacheWithNullSentinel() {
+		final Map<String, IdentifiableValue> ivs = cache.getIdentifiables(Arrays.asList("cold"));
+		final IdentifiableValue iv = ivs.get("cold");
+		assertThat(iv).isNotNull();
+		assertThat(iv.getValue()).isNull();   // sentinel decodes back to null
+	}
+
+	@Test
+	void casSucceedsOnUntouchedSentinel() {
+		final IdentifiableValue iv = cache.getIdentifiables(Arrays.asList("k")).get("k");
+
+		final Set<String> winners = cache.putIfUntouched(
+				Map.of("k", new CasPut(iv, "fresh", 0)));
+
+		assertThat(winners).containsExactly("k");
+		assertThat(cache.get("k")).isEqualTo("fresh");
+	}
+
+	@Test
+	void casFailsAfterAnotherWriterChangedTheValue() {
+		cache.put("k", "original");
+		final IdentifiableValue iv = cache.getIdentifiables(Arrays.asList("k")).get("k");
+		assertThat(iv.getValue()).isEqualTo("original");
+
+		// Simulate a competing writer.
+		cache.put("k", "stomped");
+
+		final Set<String> winners = cache.putIfUntouched(
+				Map.of("k", new CasPut(iv, "fresh", 0)));
+
+		assertThat(winners).isEmpty();
+		assertThat(cache.get("k")).isEqualTo("stomped");
+	}
+
+	@Test
+	void casReplacesExistingValueWhenUntouched() {
+		cache.put("k", "first");
+		final IdentifiableValue iv = cache.getIdentifiables(Arrays.asList("k")).get("k");
+
+		final Set<String> winners = cache.putIfUntouched(
+				Map.of("k", new CasPut(iv, "second", 0)));
+
+		assertThat(winners).containsExactly("k");
+		assertThat(cache.get("k")).isEqualTo("second");
+	}
+
+	@Test
+	void casHonorsExpirationSeconds() throws Exception {
+		final IdentifiableValue iv = cache.getIdentifiables(Arrays.asList("k")).get("k");
+
+		assertThat(cache.putIfUntouched(Map.of("k", new CasPut(iv, "ttl-value", 1))))
+				.containsExactly("k");
+		assertThat(cache.get("k")).isEqualTo("ttl-value");
+
+		Thread.sleep(2000);
+
+		assertThat(cache.get("k")).isNull();
+	}
+
+	@Test
+	void putIfUntouchedReportsPartialSuccess() {
+		final Map<String, IdentifiableValue> ivs = cache.getIdentifiables(Arrays.asList("a", "b"));
+
+		// Stomp only on "a"; "b" should still CAS successfully.
+		cache.put("a", "stomped");
+
+		final Map<String, CasPut> proposed = new LinkedHashMap<>();
+		proposed.put("a", new CasPut(ivs.get("a"), "fresh-a", 0));
+		proposed.put("b", new CasPut(ivs.get("b"), "fresh-b", 0));
+
+		final Set<String> winners = cache.putIfUntouched(proposed);
+
+		assertThat(winners).containsExactly("b");
+		assertThat(cache.get("a")).isEqualTo("stomped");
+		assertThat(cache.get("b")).isEqualTo("fresh-b");
+	}
+
+	/**
+	 * Many threads racing on the same key — exactly one CAS must win, and the cache must end up
+	 * holding the winner's value. Verifies that the CAS isn't subject to lost-update races even
+	 * under contention, which is the property memcache CAS originally provided and that the
+	 * Valkey {@code IFEQ} path needs to preserve.
+	 */
+	@Test
+	void casUnderContentionProducesExactlyOneWinner() throws Exception {
+		final String key = "contended-" + UUID.randomUUID();
+		cache.put(key, "seed");
+
+		final int writers = 10;
+		final ExecutorService pool = Executors.newFixedThreadPool(writers);
+		final CountDownLatch start = new CountDownLatch(1);
+		final AtomicInteger wins = new AtomicInteger();
+
+		try {
+			for (int i = 0; i < writers; i++) {
+				final String myValue = "writer-" + i;
+				pool.submit(() -> {
+					try {
+						start.await();
+						final IdentifiableValue iv = cache.getIdentifiables(Arrays.asList(key)).get(key);
+						final Set<String> won = cache.putIfUntouched(
+								Map.of(key, new CasPut(iv, myValue, 0)));
+						if (won.contains(key)) {
+							wins.incrementAndGet();
+						}
+					} catch (final InterruptedException ie) {
+						Thread.currentThread().interrupt();
+					}
+					return null;
+				});
+			}
+			start.countDown();
+		} finally {
+			pool.shutdown();
+			assertThat(pool.awaitTermination(15, TimeUnit.SECONDS)).isTrue();
+		}
+
+		assertThat(wins.get()).isEqualTo(1);
+		assertThat(cache.get(key)).isInstanceOf(String.class);
+		assertThat((String) cache.get(key)).startsWith("writer-");
+	}
+
+	private static class Sample implements Serializable {
+		private static final long serialVersionUID = 1L;
+		private final String s;
+		private final int n;
+
+		Sample(final String s, final int n) {
+			this.s = s;
+			this.n = n;
+		}
+
+		@Override
+		public boolean equals(final Object o) {
+			if (!(o instanceof Sample)) return false;
+			final Sample other = (Sample) o;
+			return n == other.n && s.equals(other.s);
+		}
+
+		@Override
+		public int hashCode() {
+			return s.hashCode() * 31 + n;
+		}
+	}
+}

--- a/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCachingDatastoreTests.java
+++ b/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCachingDatastoreTests.java
@@ -1,0 +1,74 @@
+package com.googlecode.objectify.test.valkey;
+
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Key;
+import com.googlecode.objectify.cache.CachingAsyncDatastore;
+import com.googlecode.objectify.cache.EntityMemcache;
+import com.googlecode.objectify.impl.AsyncDatastore;
+import com.googlecode.objectify.test.util.valkey.ValkeyTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Valkey-backed mirror of {@link com.googlecode.objectify.test.CachingDatastoreTests}.
+ */
+class ValkeyCachingDatastoreTests extends ValkeyTestBase {
+
+	private CachingAsyncDatastore cads;
+	private CachingAsyncDatastore nods;
+
+	private Key key;
+	private Set<Key> keyInSet;
+	private Entity entity;
+	private List<Entity> entityInList;
+
+	@BeforeEach
+	void setUpExtra() throws IOException {
+		final EntityMemcache mc = new EntityMemcache(memcache(), "somenamespace");
+		cads = new CachingAsyncDatastore(asyncDatastore(), mc);
+		nods = new CachingAsyncDatastore(allOperationsUnsupported(), mc);
+
+		key = datastore().newKeyFactory().setKind("thing").newKey(1);
+		keyInSet = Collections.singleton(key);
+		entity = Entity.newBuilder(key).set("foo", "bar").build();
+		entityInList = Collections.singletonList(entity);
+	}
+
+	private AsyncDatastore allOperationsUnsupported() {
+		return (AsyncDatastore) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[]{AsyncDatastore.class},
+				(p, m, a) -> { throw new UnsupportedOperationException(); });
+	}
+
+	@Test
+	void negativeCacheWorks() throws Exception {
+		final Future<Map<Key, Entity>> fent = cads.get(key);
+		assertThat(fent.get()).isEmpty();
+
+		final Future<Map<Key, Entity>> cached = nods.get(key);
+		assertThat(cached.get()).isEmpty();
+	}
+
+	@Test
+	void basicCacheWorks() throws Exception {
+		final Future<List<Key>> fkey = cads.put(entityInList);
+		final List<Key> putResult = fkey.get();
+
+		final Future<Map<Key, Entity>> fent = cads.get(putResult);
+		final Entity fentEntity = fent.get().values().iterator().next();
+		assertThat(fentEntity.getString("foo")).isEqualTo("bar");
+
+		final Future<Map<Key, Entity>> cached = nods.get(putResult);
+		final Entity cachedEntity = cached.get().values().iterator().next();
+		assertThat(cachedEntity.getString("foo")).isEqualTo("bar");
+	}
+}

--- a/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCachingTests.java
+++ b/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCachingTests.java
@@ -1,0 +1,95 @@
+package com.googlecode.objectify.test.valkey;
+
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.annotation.Cache;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.test.util.valkey.ValkeyTestBase;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.googlecode.objectify.ObjectifyService.factory;
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+/**
+ * Valkey-backed mirror of {@link com.googlecode.objectify.test.CachingTests}.
+ */
+class ValkeyCachingTests extends ValkeyTestBase {
+
+	@Entity
+	@Data
+	@NoArgsConstructor
+	private static class Uncached {
+		@Id
+		private Long id;
+		private String stuff;
+
+		Uncached(final String stuff) {
+			this.stuff = stuff;
+		}
+	}
+
+	@Entity
+	@Cache
+	@Data
+	@NoArgsConstructor
+	private static class Cached {
+		@Id
+		private Long id;
+		private String stuff;
+
+		Cached(final String stuff) {
+			this.stuff = stuff;
+		}
+	}
+
+	@BeforeEach
+	void setUpExtra() {
+		factory().register(Uncached.class);
+		factory().register(Cached.class);
+	}
+
+	@Test
+	void batchFetchSomeCachedSomeUncached() {
+		final Uncached un1 = new Uncached("un1 stuff");
+		final Uncached un2 = new Uncached("un2 stuff");
+		final Cached ca1 = new Cached("ca1 stuff");
+		final Cached ca2 = new Cached("ca2 stuff");
+
+		final List<Object> entities = Arrays.asList(un1, ca1, un2, ca2);
+
+		final Map<Key<Object>, Object> keys = ofy().save().entities(entities).now();
+		ofy().clear();
+		final Map<Key<Object>, Object> fetched = ofy().load().keys(keys.keySet());
+
+		assertThat(fetched.keySet()).containsExactlyElementsIn(keys.keySet()).inOrder();
+	}
+
+	@Entity
+	@Cache(expirationSeconds = 2)
+	@Data
+	private static class Expires {
+		@Id
+		private Long id;
+		private String stuff;
+	}
+
+	@Test
+	void cacheExpirationWorks() {
+		factory().register(Expires.class);
+
+		final Expires exp = new Expires();
+		exp.stuff = "foo";
+
+		final Key<Expires> key = ofy().save().entity(exp).now();
+		ofy().clear();
+		ofy().load().key(key).now();   // pull through cache so it gets stored with TTL
+	}
+}

--- a/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCachingUncacheableTests.java
+++ b/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCachingUncacheableTests.java
@@ -1,0 +1,72 @@
+package com.googlecode.objectify.test.valkey;
+
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.ObjectifyFactory;
+import com.googlecode.objectify.ObjectifyService;
+import com.googlecode.objectify.annotation.Cache;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.cache.MemcacheService;
+import com.googlecode.objectify.test.util.valkey.ValkeyTestBase;
+import com.googlecode.objectify.util.Closeable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.googlecode.objectify.ObjectifyService.factory;
+import static com.googlecode.objectify.ObjectifyService.ofy;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Valkey-backed mirror of {@link com.googlecode.objectify.test.CachingUncacheableTests}. Verifies
+ * that an entity without {@link Cache} never causes a call into the cache service.
+ */
+class ValkeyCachingUncacheableTests extends ValkeyTestBase {
+
+	@Entity
+	private static class Uncacheable {
+		@Id Long id;
+		String stuff;
+	}
+
+	@Entity
+	@Cache
+	private static class Cacheable {
+		@Id Long id;
+		String stuff;
+	}
+
+	private Closeable rootService;
+
+	@Mock
+	private MemcacheService memcacheService;
+
+	@BeforeEach
+	void setUpExtra() {
+		ObjectifyService.init(new ObjectifyFactory(datastore(), memcacheService));
+		factory().register(Uncacheable.class);
+		factory().register(Cacheable.class);
+
+		rootService = ObjectifyService.begin();
+	}
+
+	@AfterEach
+	void tearDownExtra() {
+		rootService.close();
+	}
+
+	@Test
+	void ensureUncacheableThingsDoNotTouchCache() {
+		final Uncacheable un1 = new Uncacheable();
+		un1.stuff = "un1 stuff";
+
+		final Key<Uncacheable> key = ofy().save().entity(un1).now();
+		ofy().clear();
+		final Uncacheable fetched = ofy().load().key(key).now();
+
+		assertThat(fetched).isNotNull();
+		verifyNoInteractions(memcacheService);
+	}
+}

--- a/src/test/java/com/googlecode/objectify/test/valkey/ValkeyEvilCacheBugTests.java
+++ b/src/test/java/com/googlecode/objectify/test/valkey/ValkeyEvilCacheBugTests.java
@@ -1,0 +1,95 @@
+package com.googlecode.objectify.test.valkey;
+
+import com.google.cloud.datastore.Entity;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.TxnOptions;
+import com.googlecode.objectify.annotation.Cache;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.Parent;
+import com.googlecode.objectify.cache.CachingAsyncDatastore;
+import com.googlecode.objectify.cache.EntityMemcache;
+import com.googlecode.objectify.impl.AsyncDatastore;
+import com.googlecode.objectify.impl.AsyncDatastoreImpl;
+import com.googlecode.objectify.impl.AsyncTransaction;
+import com.googlecode.objectify.test.util.valkey.ValkeyTestBase;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.googlecode.objectify.ObjectifyService.factory;
+
+/**
+ * Valkey-backed mirror of {@link com.googlecode.objectify.test.EvilMemcacheBugTests}. The original
+ * test caught a regression where in-flight transaction state polluted the cache; we re-run it
+ * against the Valkey backend to ensure the CAS path doesn't reintroduce the issue.
+ */
+class ValkeyEvilCacheBugTests extends ValkeyTestBase {
+
+	@com.googlecode.objectify.annotation.Entity
+	@Data
+	@NoArgsConstructor
+	private static class SimpleParent {
+		@Id String id;
+
+		SimpleParent(String id) {
+			this.id = id;
+		}
+
+		static Key<SimpleParent> getSimpleParentKey(String id) {
+			return Key.create(SimpleParent.class, id);
+		}
+	}
+
+	@com.googlecode.objectify.annotation.Entity
+	@Cache
+	@Data
+	@NoArgsConstructor
+	private static class SimpleEntity {
+		@Parent Key<SimpleParent> simpleParentKey;
+		@Id String id;
+
+		String foo = "bar";
+
+		static Key<SimpleEntity> getSimpleChildKey(String id) {
+			return Key.create(SimpleParent.getSimpleParentKey(id), SimpleEntity.class, id);
+		}
+
+		SimpleEntity(String id) {
+			this.id = id;
+			this.simpleParentKey = SimpleParent.getSimpleParentKey(id);
+		}
+	}
+
+	@Test
+	void testRawTransactionalCaching() throws Exception {
+		factory().register(SimpleEntity.class);
+
+		final EntityMemcache mc = new EntityMemcache(memcache(), "somenamespace");
+		final AsyncDatastore cacheds = new CachingAsyncDatastore(new AsyncDatastoreImpl(datastore()), mc);
+
+		final com.google.cloud.datastore.Key parentKey = datastore().newKeyFactory().setKind("SimpleParent").newKey("asdf");
+		final com.google.cloud.datastore.Key childKey = com.google.cloud.datastore.Key.newBuilder(parentKey, "SimpleEntity", "asdf").build();
+
+		final Entity ent1 = Entity.newBuilder(childKey).set("foo", "original").build();
+		cacheds.put(ent1);
+
+		final AsyncTransaction txn = cacheds.newTransaction(TxnOptions.deflt(), () -> {}, Optional.empty());
+		try {
+			final Entity ent2 = txn.get(childKey).get().values().iterator().next();
+
+			final Entity ent2a = Entity.newBuilder(ent2).set("foo", "changed").build();
+			txn.put(ent2a);
+			txn.commit();
+		} finally {
+			if (txn.isActive())
+				txn.rollback();
+		}
+
+		final Entity ent3 = cacheds.get(childKey).get().values().iterator().next();
+
+		assertThat(ent3.getString("foo")).isEqualTo("changed");
+	}
+}


### PR DESCRIPTION
Implements ValkeyCacheService using the native SET ... IFEQ comparison-value [EX seconds] command introduced in Valkey 8.1/9.0, so CAS is a single round trip per key instead of a WATCH/MULTI/EXEC dance. Cold-cache reads bootstrap a single-byte 0x00 null sentinel via SET NX (the sentinel cannot collide with Java-serialized data, which always begins 0xAC 0xED).

Adds TestContainers-based extensions and ports BasicCache, Caching, CachingDatastore, CachingUncacheable, and EvilMemcacheBug tests to run against a real valkey/valkey:9.0 container. Includes a new ValkeyCacheServiceTests with direct coverage of the null sentinel, cold-cache bootstrap, CAS win/lose/replace/partial-success, native EX expiration, and a multi-threaded contention test asserting exactly one CAS winner.