### PR TITLE
Valkey cache: cluster support and a default TTL

### DIFF
--- a/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
+++ b/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
@@ -2,10 +2,15 @@ package com.googlecode.objectify.cache.valkey;
 
 import com.googlecode.objectify.cache.IdentifiableValue;
 import com.googlecode.objectify.cache.MemcacheService;
+import glide.api.BaseClient;
 import glide.api.GlideClient;
+import glide.api.GlideClusterClient;
 import glide.api.models.GlideString;
 import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.SetOptions.ConditionalSet;
+import glide.api.models.configuration.RequestRoutingConfiguration.Route;
+import glide.api.models.configuration.RequestRoutingConfiguration.SlotKeyRoute;
+import glide.api.models.configuration.RequestRoutingConfiguration.SlotType;
 import lombok.RequiredArgsConstructor;
 
 import java.io.ByteArrayInputStream;
@@ -14,23 +19,32 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static glide.api.models.GlideString.gs;
 
 /**
- * A {@link MemcacheService} backed by Valkey 9.0+ using the valkey-glide client.
+ * A {@link MemcacheService} backed by Valkey 8.1+ using the valkey-glide client.
  *
- * <p>Compare-and-swap is implemented with the native {@code SET key value IFEQ comparison-value}
- * command introduced in Valkey 8.1 (and rounded out in 9.0 with companion commands like
- * {@code DELIFEQ}). This is one round trip per key, versus the multi-step
- * {@code WATCH/GET/MULTI/SET/EXEC} dance required on older Redis-compatible servers.</p>
+ * <p>Works against both a standalone server and a cluster: the client is held as a
+ * {@link BaseClient} (either a {@code GlideClient} or a {@code GlideClusterClient}), and every
+ * operation is single-key or routed by key. Multi-key reads/writes/deletes are issued as
+ * independent per-key commands fired concurrently rather than {@code MGET}/{@code MSET}/{@code DEL
+ * key...}, which would fail with {@code CROSSSLOT} on a cluster.</p>
+ *
+ * <p>Compare-and-swap uses the native {@code SET key value IFEQ comparison-value} command
+ * introduced in Valkey 8.1 — one round trip per key, with the comparison performed server-side. On
+ * a cluster the command is routed explicitly to the primary owning the key's slot
+ * ({@link SlotKeyRoute}); on standalone it is issued directly.</p>
  *
  * <p>Cold-cache handling: {@code IFEQ} requires the key to exist with the comparison value, so on
  * a miss {@link #getIdentifiables} bootstraps a single-byte null sentinel via {@code SET NX} and
@@ -49,7 +63,11 @@ public class ValkeyCacheService implements MemcacheService {
 	/** "OK" reply from Valkey when a write succeeds. */
 	private static final String OK = "OK";
 
-	private final GlideClient client;
+	/**
+	 * BaseClient so this works with either the standalone (GlideClient) or cluster
+	 * (GlideClusterClient) valkey client; every operation is single-key or key-routed.
+	 */
+	private final BaseClient client;
 
 	private static byte[] toCacheBytes(final Object thing) {
 		if (thing == null) {
@@ -81,7 +99,7 @@ public class ValkeyCacheService implements MemcacheService {
 		return gs(key.getBytes(StandardCharsets.UTF_8));
 	}
 
-	private static <T> T await(final java.util.concurrent.CompletableFuture<T> future) {
+	private static <T> T await(final CompletableFuture<T> future) {
 		try {
 			return future.get();
 		} catch (final InterruptedException e) {
@@ -135,19 +153,17 @@ public class ValkeyCacheService implements MemcacheService {
 			return result;
 		}
 
-		final GlideString[] keyArray = keys.stream()
-				.map(ValkeyCacheService::gskey)
-				.toArray(GlideString[]::new);
-
-		final Object[] values = await(client.mget(keyArray));
-
-		int i = 0;
+		// Per-key GETs fired concurrently (no MGET, which would CROSSSLOT on a cluster).
+		final Map<String, CompletableFuture<GlideString>> futures = new LinkedHashMap<>();
 		for (final String key : keys) {
-			final Object raw = values[i++];
-			if (raw != null) {
-				result.put(key, fromCacheBytes(((GlideString) raw).getBytes()));
-			}
+			futures.put(key, client.get(gskey(key)));
 		}
+		futures.forEach((key, future) -> {
+			final GlideString value = await(future);
+			if (value != null) {
+				result.put(key, fromCacheBytes(value.getBytes()));
+			}
+		});
 		return result;
 	}
 
@@ -161,47 +177,64 @@ public class ValkeyCacheService implements MemcacheService {
 		if (values.isEmpty()) {
 			return;
 		}
-		final Map<GlideString, GlideString> mapping = new LinkedHashMap<>();
-		values.forEach((key, value) -> mapping.put(gskey(key), gs(toCacheBytes(value))));
-		await(client.msetBinary(mapping));
+		// Per-key SETs fired concurrently (no MSET, which would CROSSSLOT on a cluster).
+		final List<CompletableFuture<String>> futures = new ArrayList<>();
+		values.forEach((key, value) -> futures.add(client.set(gskey(key), gs(toCacheBytes(value)))));
+		futures.forEach(ValkeyCacheService::await);
 	}
 
 	/**
-	 * Atomically writes new values only when the existing bytes still match the snapshot taken
-	 * at {@link #getIdentifiables} time. Each key issues a single
+	 * Atomically writes new values only when the existing bytes still match the snapshot taken at
+	 * {@link #getIdentifiables} time. Each key issues a single
 	 * {@code SET key value IFEQ comparison-value [EX seconds]} command; Valkey performs the
 	 * comparison server-side and either commits the write (returning {@code "OK"}) or aborts
-	 * (returning {@code nil}).
+	 * (returning {@code nil}). On a cluster each command is routed to the primary owning the key.
 	 */
 	@Override
 	public Set<String> putIfUntouched(final Map<String, CasPut> values) {
-		final Set<String> successes = new HashSet<>();
-
+		final Map<String, CompletableFuture<Boolean>> futures = new LinkedHashMap<>();
 		for (final Map.Entry<String, CasPut> entry : values.entrySet()) {
 			final String key = entry.getKey();
 			final CasPut casPut = entry.getValue();
 			final ValkeyIdentifiableValue viv = (ValkeyIdentifiableValue) casPut.getIv();
 
-			final byte[] expected = viv.getRawBytes();
-			final byte[] next = toCacheBytes(casPut.getNextToStore());
+			final GlideString expected = gs(viv.getRawBytes());
+			final GlideString next = gs(toCacheBytes(casPut.getNextToStore()));
 			final int ttl = casPut.getExpirationSeconds();
 
 			final GlideString[] args = ttl > 0
 					? new GlideString[]{
-							gs("SET"), gskey(key), gs(next),
-							gs("IFEQ"), gs(expected),
+							gs("SET"), gskey(key), next,
+							gs("IFEQ"), expected,
 							gs("EX"), gs(Integer.toString(ttl))}
 					: new GlideString[]{
-							gs("SET"), gskey(key), gs(next),
-							gs("IFEQ"), gs(expected)};
+							gs("SET"), gskey(key), next,
+							gs("IFEQ"), expected};
 
-			final Object response = await(client.customCommand(args));
-			if (isOk(response)) {
-				successes.add(key);
-			}
+			futures.put(key, casAsync(key, args));
 		}
 
+		final Set<String> successes = new HashSet<>();
+		futures.forEach((key, future) -> {
+			if (Boolean.TRUE.equals(await(future))) {
+				successes.add(key);
+			}
+		});
 		return successes;
+	}
+
+	/**
+	 * Issues a custom {@code SET ... IFEQ} command, routing it to the key's slot on a cluster.
+	 * {@code customCommand} is not part of {@link BaseClient} and returns a {@code ClusterValue} on
+	 * the cluster client, so the two client types are handled explicitly here.
+	 */
+	private CompletableFuture<Boolean> casAsync(final String key, final GlideString[] args) {
+		if (client instanceof GlideClusterClient) {
+			final Route route = new SlotKeyRoute(key, SlotType.PRIMARY);
+			return ((GlideClusterClient) client).customCommand(args, route)
+					.thenApply(clusterValue -> isOk(clusterValue.getSingleValue()));
+		}
+		return ((GlideClient) client).customCommand(args).thenApply(ValkeyCacheService::isOk);
 	}
 
 	private static boolean isOk(final Object response) {
@@ -225,9 +258,11 @@ public class ValkeyCacheService implements MemcacheService {
 		if (keys.isEmpty()) {
 			return;
 		}
-		final GlideString[] keyArray = keys.stream()
-				.map(ValkeyCacheService::gskey)
-				.toArray(GlideString[]::new);
-		await(client.del(keyArray));
+		// Per-key DELs fired concurrently (no multi-key DEL, which would CROSSSLOT on a cluster).
+		final List<CompletableFuture<Long>> futures = new ArrayList<>();
+		for (final String key : keys) {
+			futures.add(client.del(new GlideString[]{gskey(key)}));
+		}
+		futures.forEach(ValkeyCacheService::await);
 	}
 }

--- a/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
+++ b/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
@@ -11,7 +11,6 @@ import glide.api.models.commands.SetOptions.ConditionalSet;
 import glide.api.models.configuration.RequestRoutingConfiguration.Route;
 import glide.api.models.configuration.RequestRoutingConfiguration.SlotKeyRoute;
 import glide.api.models.configuration.RequestRoutingConfiguration.SlotType;
-import lombok.RequiredArgsConstructor;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -53,8 +52,15 @@ import static glide.api.models.GlideString.gs;
  *
  * <p>Null values are stored as a single {@code 0x00} byte. Java-serialized objects always begin
  * with the magic bytes {@code 0xAC 0xED}, so the sentinel can never collide with a real value.</p>
+ *
+ * <p><b>Expiration.</b> Every write carries a TTL so the keyspace stays bounded. Memcache-backed
+ * caches shed cold entries via LRU eviction; a Valkey cluster configured with {@code noeviction}
+ * cannot, so a persistent write pattern grows until {@code maxmemory} is hit and every subsequent
+ * write (including unrelated callers sharing the cluster) fails with {@code OOM}. Entities that
+ * declare their own expiration keep it; everything else — plain {@link #put}/{@link #putAll}
+ * writes, the cold-cache null sentinel, and CAS writes with no explicit TTL — falls back to
+ * {@code defaultExpirationSeconds}.</p>
  */
-@RequiredArgsConstructor
 public class ValkeyCacheService implements MemcacheService {
 
 	/** Single-byte sentinel for null. Cannot collide with Java-serialized data (which starts 0xAC 0xED). */
@@ -63,11 +69,35 @@ public class ValkeyCacheService implements MemcacheService {
 	/** "OK" reply from Valkey when a write succeeds. */
 	private static final String OK = "OK";
 
+	/** Default TTL (24 hours) applied to writes that don't carry an explicit expiration. */
+	public static final int DEFAULT_EXPIRATION_SECONDS = 86_400;
+
 	/**
 	 * BaseClient so this works with either the standalone (GlideClient) or cluster
 	 * (GlideClusterClient) valkey client; every operation is single-key or key-routed.
 	 */
 	private final BaseClient client;
+
+	/** Fallback TTL (seconds) for writes that don't specify their own; keeps the keyspace bounded. */
+	private final int defaultExpirationSeconds;
+
+	/** Uses {@link #DEFAULT_EXPIRATION_SECONDS} as the fallback TTL. */
+	public ValkeyCacheService(final BaseClient client) {
+		this(client, DEFAULT_EXPIRATION_SECONDS);
+	}
+
+	public ValkeyCacheService(final BaseClient client, final int defaultExpirationSeconds) {
+		if (defaultExpirationSeconds <= 0) {
+			throw new IllegalArgumentException("defaultExpirationSeconds must be positive, got " + defaultExpirationSeconds);
+		}
+		this.client = client;
+		this.defaultExpirationSeconds = defaultExpirationSeconds;
+	}
+
+	/** SET options that expire the key after {@link #defaultExpirationSeconds}. */
+	private SetOptions withDefaultTtl() {
+		return SetOptions.builder().expiry(SetOptions.Expiry.Seconds((long) defaultExpirationSeconds)).build();
+	}
 
 	private static byte[] toCacheBytes(final Object thing) {
 		if (thing == null) {
@@ -137,8 +167,11 @@ public class ValkeyCacheService implements MemcacheService {
 
 		// Cold cache: bootstrap a sentinel under NX so we can later CAS against it. NX prevents
 		// us from clobbering a value another caller has just set in between our GET and our SET.
+		// TTL-bounded like every other write: a read-heavy workload bootstraps a sentinel per
+		// cold key, and without expiry those persist forever on a noeviction cluster.
 		final SetOptions nx = SetOptions.builder()
 				.conditionalSet(ConditionalSet.ONLY_IF_DOES_NOT_EXIST)
+				.expiry(SetOptions.Expiry.Seconds((long) defaultExpirationSeconds))
 				.build();
 		await(client.set(gskey(key), gs(NULL_VALUE), nx));
 
@@ -169,7 +202,7 @@ public class ValkeyCacheService implements MemcacheService {
 
 	@Override
 	public void put(final String key, final Object thing) {
-		await(client.set(gskey(key), gs(toCacheBytes(thing))));
+		await(client.set(gskey(key), gs(toCacheBytes(thing)), withDefaultTtl()));
 	}
 
 	@Override
@@ -179,7 +212,7 @@ public class ValkeyCacheService implements MemcacheService {
 		}
 		// Per-key SETs fired concurrently (no MSET, which would CROSSSLOT on a cluster).
 		final List<CompletableFuture<String>> futures = new ArrayList<>();
-		values.forEach((key, value) -> futures.add(client.set(gskey(key), gs(toCacheBytes(value)))));
+		values.forEach((key, value) -> futures.add(client.set(gskey(key), gs(toCacheBytes(value)), withDefaultTtl())));
 		futures.forEach(ValkeyCacheService::await);
 	}
 
@@ -200,16 +233,15 @@ public class ValkeyCacheService implements MemcacheService {
 
 			final GlideString expected = gs(viv.getRawBytes());
 			final GlideString next = gs(toCacheBytes(casPut.getNextToStore()));
-			final int ttl = casPut.getExpirationSeconds();
+			// Honor an entity's own expiration; otherwise fall back to the default TTL so CAS writes
+			// stay bounded like plain puts (0 previously meant "never expire").
+			final int explicitTtl = casPut.getExpirationSeconds();
+			final int ttl = explicitTtl > 0 ? explicitTtl : defaultExpirationSeconds;
 
-			final GlideString[] args = ttl > 0
-					? new GlideString[]{
-							gs("SET"), gskey(key), next,
-							gs("IFEQ"), expected,
-							gs("EX"), gs(Integer.toString(ttl))}
-					: new GlideString[]{
-							gs("SET"), gskey(key), next,
-							gs("IFEQ"), expected};
+			final GlideString[] args = new GlideString[]{
+					gs("SET"), gskey(key), next,
+					gs("IFEQ"), expected,
+					gs("EX"), gs(Integer.toString(ttl))};
 
 			futures.put(key, casAsync(key, args));
 		}

--- a/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCacheServiceTests.java
+++ b/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCacheServiceTests.java
@@ -33,7 +33,8 @@ import static com.google.common.truth.Truth.assertThat;
  * Direct unit tests for {@link ValkeyCacheService}, covering the behavior the higher-level
  * {@code EntityMemcache}-driven tests don't exercise: the null sentinel on cold-cache reads,
  * the {@code SET ... IFEQ} CAS contract for both winners and losers, native {@code EX seconds}
- * expiration, and a multi-threaded race where only one CAS may win.
+ * expiration, the default TTL applied to writes that don't declare one, and a multi-threaded race
+ * where only one CAS may win.
  */
 class ValkeyCacheServiceTests {
 
@@ -164,6 +165,51 @@ class ValkeyCacheServiceTests {
 	}
 
 	@Test
+	void putAppliesDefaultTtl() throws Exception {
+		final MemcacheService ttlCache = new ValkeyCacheService(client, 100);
+		ttlCache.put("k", "v");
+		assertThat(ttlOf("k")).isGreaterThan(0L);
+		assertThat(ttlOf("k")).isAtMost(100L);
+	}
+
+	@Test
+	void putAllAppliesDefaultTtl() throws Exception {
+		final MemcacheService ttlCache = new ValkeyCacheService(client, 100);
+		final Map<String, Object> in = new LinkedHashMap<>();
+		in.put("a", "alpha");
+		ttlCache.putAll(in);
+		assertThat(ttlOf("a")).isGreaterThan(0L);
+		assertThat(ttlOf("a")).isAtMost(100L);
+	}
+
+	@Test
+	void coldCacheSentinelAppliesDefaultTtl() throws Exception {
+		final MemcacheService ttlCache = new ValkeyCacheService(client, 100);
+		ttlCache.getIdentifiables(Arrays.asList("cold"));
+		assertThat(ttlOf("cold")).isGreaterThan(0L);
+		assertThat(ttlOf("cold")).isAtMost(100L);
+	}
+
+	@Test
+	void casFallsBackToDefaultTtlWhenUnset() throws Exception {
+		final MemcacheService ttlCache = new ValkeyCacheService(client, 100);
+		final IdentifiableValue iv = ttlCache.getIdentifiables(Arrays.asList("k")).get("k");
+		assertThat(ttlCache.putIfUntouched(Map.of("k", new CasPut(iv, "v", 0)))).containsExactly("k");
+		assertThat(ttlOf("k")).isGreaterThan(0L);
+		assertThat(ttlOf("k")).isAtMost(100L);
+	}
+
+	@Test
+	void rejectsNonPositiveDefaultTtl() {
+		try {
+			new ValkeyCacheService(client, 0);
+			throw new AssertionError("expected IllegalArgumentException");
+		} catch (final IllegalArgumentException expected) {
+			// expected
+		}
+	}
+
+	@Test
 	void casHonorsExpirationSeconds() throws Exception {
 		final IdentifiableValue iv = cache.getIdentifiables(Arrays.asList("k")).get("k");
 
@@ -237,6 +283,11 @@ class ValkeyCacheServiceTests {
 		assertThat(wins.get()).isEqualTo(1);
 		assertThat(cache.get(key)).isInstanceOf(String.class);
 		assertThat((String) cache.get(key)).startsWith("writer-");
+	}
+
+	/** Remaining TTL (seconds) on a key, or a negative sentinel (-1 no expiry, -2 absent) per the Valkey TTL contract. */
+	private long ttlOf(final String key) throws Exception {
+		return ((Number) client.customCommand(new String[]{"TTL", key}).get()).longValue();
 	}
 
 	private static class Sample implements Serializable {


### PR DESCRIPTION
Follow-up to #527, from running that cache in production.

**1. Cluster support.** `ValkeyCacheService` only worked against a standalone server. `MGET`/`MSET`/multi-key `DEL` fail with `CROSSSLOT` on a cluster as soon as the keys hash to different slots, which is the normal case for Objectify keys. This holds the client as `BaseClient` so either a `GlideClient` or a `GlideClusterClient` can be supplied, and issues the multi-key operations as independent per-key commands fired concurrently (glide multiplexes them over the connection, so this costs one round trip's worth of latency, not N). The `SET ... IFEQ` CAS is unchanged except that on a cluster it is routed to the primary owning the key's slot.

**2. Default TTL.** Every write path went in without an expiration, including the cold-cache null sentinel that `getIdentifiables` bootstraps on every miss. Under memcache that is harmless — LRU evicts cold entries. Valkey with `noeviction` does not: the keyspace grows until `maxmemory`, and then all writes to that server start failing with `OOM`, including writes from anything else sharing the cluster. Writes now carry a TTL (default 24h, overridable via a new constructor); an entity's own `expirationSeconds` still wins where it declares one.

Note that this changes the constructor signature (`GlideClient` → `BaseClient`, and the lombok-generated constructor becomes explicit so the TTL can be defaulted). `ValkeyCacheService` hasn't shipped in a release yet, and `GlideClient` is a `BaseClient`, so existing source keeps compiling.

**Testing.** `ValkeyCacheServiceTests` covers the rewritten multi-key paths and adds coverage for the default TTL on `put`, `putAll`, the cold-cache sentinel, and CAS without an explicit expiration. All 25 tests under `src/test/java/com/googlecode/objectify/test/valkey` pass locally.

The cluster routing itself is not covered by a test: testcontainers can't easily expose a real cluster's advertised node addresses to the host in a way that works on both Linux and Docker Desktop. It has been exercised against a live multi-node Valkey cluster in production. Happy to attempt a Linux-only cluster test if you'd want one.