### PR TITLE
Valkey cache: compress large values, allow a caller-supplied ObjectInputStream

### DIFF
--- a/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
+++ b/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
@@ -15,6 +15,7 @@ import glide.api.models.configuration.RequestRoutingConfiguration.SlotType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -25,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -81,6 +83,22 @@ import static glide.api.models.GlideString.gs;
  */
 public class ValkeyCacheService implements MemcacheService {
 
+	/**
+	 * Wraps the raw bytes of a stored value in the {@link ObjectInputStream} used to deserialize it.
+	 * The default is a plain {@link ObjectInputStream}, which resolves classes by their exact stored
+	 * name. Callers that need something else — most commonly a subclass overriding
+	 * {@link ObjectInputStream#resolveClass} to map class names written by a differently-built process,
+	 * such as one whose dependencies were relocated by a shading step — can supply their own. That lets
+	 * processes with different relocation schemes share a single cache instead of each needing its own.
+	 *
+	 * <p>Kept as an explicit interface rather than a {@code Function<InputStream, ObjectInputStream>}
+	 * because the {@link ObjectInputStream} constructor throws {@link IOException}.</p>
+	 */
+	@FunctionalInterface
+	public interface ObjectInputStreamFactory {
+		ObjectInputStream create(InputStream in) throws IOException;
+	}
+
 	/** Single-byte sentinel for null. Cannot collide with Java-serialized data (which starts 0xAC 0xED). */
 	private static final byte[] NULL_VALUE = new byte[]{0};
 
@@ -124,17 +142,34 @@ public class ValkeyCacheService implements MemcacheService {
 	/** Cold-cache sentinel options: {@code NX} plus the default TTL. Pre-built for the same reason as {@link #defaultSetOptions}. */
 	private final SetOptions defaultNxSetOptions;
 
-	/** Uses {@link #DEFAULT_EXPIRATION_SECONDS} as the fallback TTL. */
+	/** Builds the {@link ObjectInputStream} used on the read path; see {@link ObjectInputStreamFactory}. */
+	private final ObjectInputStreamFactory objectInputStreamFactory;
+
+	/** Uses {@link #DEFAULT_EXPIRATION_SECONDS} as the fallback TTL and a plain {@link ObjectInputStream}. */
 	public ValkeyCacheService(final BaseClient client) {
 		this(client, DEFAULT_EXPIRATION_SECONDS);
 	}
 
+	/** Uses {@link #DEFAULT_EXPIRATION_SECONDS} as the fallback TTL. */
+	public ValkeyCacheService(final BaseClient client, final ObjectInputStreamFactory objectInputStreamFactory) {
+		this(client, DEFAULT_EXPIRATION_SECONDS, objectInputStreamFactory);
+	}
+
+	/** Uses a plain {@link ObjectInputStream} on the read path. */
 	public ValkeyCacheService(final BaseClient client, final int defaultExpirationSeconds) {
+		this(client, defaultExpirationSeconds, ObjectInputStream::new);
+	}
+
+	public ValkeyCacheService(
+			final BaseClient client,
+			final int defaultExpirationSeconds,
+			final ObjectInputStreamFactory objectInputStreamFactory) {
 		if (defaultExpirationSeconds <= 0) {
 			throw new IllegalArgumentException("defaultExpirationSeconds must be positive, got " + defaultExpirationSeconds);
 		}
 		this.client = client;
 		this.defaultExpirationSeconds = defaultExpirationSeconds;
+		this.objectInputStreamFactory = Objects.requireNonNull(objectInputStreamFactory, "objectInputStreamFactory");
 		this.defaultSetOptions = SetOptions.builder()
 				.expiry(SetOptions.Expiry.Seconds((long) defaultExpirationSeconds))
 				.build();
@@ -158,7 +193,7 @@ public class ValkeyCacheService implements MemcacheService {
 		return deflate(serialized);
 	}
 
-	private static Object fromCacheBytes(final byte[] bytes) {
+	private Object fromCacheBytes(final byte[] bytes) {
 		if (bytes == null || Arrays.equals(bytes, NULL_VALUE)) {
 			return null;
 		}
@@ -182,9 +217,9 @@ public class ValkeyCacheService implements MemcacheService {
 		}
 	}
 
-	private static Object deserialize(final byte[] serialized) {
+	private Object deserialize(final byte[] serialized) {
 		try (final ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
-			 final ObjectInputStream ois = new ObjectInputStream(bais)) {
+			 final ObjectInputStream ois = objectInputStreamFactory.create(bais)) {
 			return ois.readObject();
 		} catch (final IOException | ClassNotFoundException e) {
 			throw new RuntimeException("Failed to deserialize cache value", e);

--- a/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
+++ b/src/main/java/com/googlecode/objectify/cache/valkey/ValkeyCacheService.java
@@ -28,6 +28,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.zip.DataFormatException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
 
 import static glide.api.models.GlideString.gs;
 
@@ -50,8 +53,23 @@ import static glide.api.models.GlideString.gs;
  * then re-reads the key. The bootstrap value is what subsequent {@link #putIfUntouched} calls
  * compare against, mirroring the {@code add}-then-{@code gets} pattern used for memcached.</p>
  *
- * <p>Null values are stored as a single {@code 0x00} byte. Java-serialized objects always begin
- * with the magic bytes {@code 0xAC 0xED}, so the sentinel can never collide with a real value.</p>
+ * <p><b>Wire format.</b> The first byte of every stored value identifies its encoding, and the three
+ * possibilities can never collide:
+ * <ul>
+ *   <li>{@code 0x00} — the null sentinel (a single byte; memcache couldn't store nulls either).</li>
+ *   <li>{@code 0xAC} — an uncompressed Java-serialized object (the serialization stream magic is
+ *       {@code 0xAC 0xED}).</li>
+ *   <li>{@code 0x01} — a Deflate-compressed Java-serialized object; the compressed stream follows
+ *       the marker byte.</li>
+ * </ul>
+ * Values are compressed only when their serialized form reaches {@link #COMPRESSION_THRESHOLD_BYTES}
+ * (tiny values don't benefit and would just burn CPU on the write path). The memcache path
+ * compressed only above ~16&nbsp;KB (spymemcached's default); this threshold is deliberately lower so
+ * more of the keyspace is compressed, trading a little CPU on mid-size values for a materially
+ * smaller keyspace — which matters more here, since a Valkey instance is bounded by {@code maxmemory}
+ * rather than transparently evicting like memcache. Reads accept either form, so the cache stays
+ * readable across a rollout and after a rollback — entries written before this change, and any
+ * below the threshold, are plain uncompressed serializations.</p>
  *
  * <p><b>Expiration.</b> Every write carries a TTL so the keyspace stays bounded. Memcache-backed
  * caches shed cold entries via LRU eviction; a Valkey cluster configured with {@code noeviction}
@@ -65,6 +83,21 @@ public class ValkeyCacheService implements MemcacheService {
 
 	/** Single-byte sentinel for null. Cannot collide with Java-serialized data (which starts 0xAC 0xED). */
 	private static final byte[] NULL_VALUE = new byte[]{0};
+
+	/**
+	 * Marker byte prefixing a Deflate-compressed payload. Distinct from the null sentinel ({@code 0x00})
+	 * and from the {@code 0xAC} that opens every Java serialization stream, so {@link #fromCacheBytes}
+	 * can tell the three encodings apart from the first byte alone.
+	 */
+	private static final byte FORMAT_DEFLATE = 0x01;
+
+	/**
+	 * Serialized values at least this large are Deflate-compressed before storage; smaller ones are
+	 * stored as-is. Set to 2&nbsp;KB — well below the ~16&nbsp;KB spymemcached's default transcoder used —
+	 * to compress a larger share of the keyspace and relieve Valkey memory pressure; values under a couple
+	 * KB compress poorly and aren't worth the CPU on the request hot path.
+	 */
+	public static final int COMPRESSION_THRESHOLD_BYTES = 2_048;
 
 	/** "OK" reply from Valkey when a write succeeds. */
 	private static final String OK = "OK";
@@ -115,6 +148,30 @@ public class ValkeyCacheService implements MemcacheService {
 		if (thing == null) {
 			return NULL_VALUE;
 		}
+		final byte[] serialized = serialize(thing);
+		// Compress only above the threshold: below it Deflate rarely pays for itself (and can even grow
+		// tiny payloads) while still costing CPU on the write hot path. Above it, compression keeps large
+		// entities from taking a disproportionate share of the server's memory.
+		if (serialized.length < COMPRESSION_THRESHOLD_BYTES) {
+			return serialized;
+		}
+		return deflate(serialized);
+	}
+
+	private static Object fromCacheBytes(final byte[] bytes) {
+		if (bytes == null || Arrays.equals(bytes, NULL_VALUE)) {
+			return null;
+		}
+		// The first byte identifies the encoding (see the class javadoc). A FORMAT_DEFLATE marker means the
+		// remainder is a compressed stream; anything else is a bare Java serialization — including every
+		// entry written before compression existed — so old and new values both read back correctly.
+		final byte[] serialized = (bytes.length > 0 && bytes[0] == FORMAT_DEFLATE)
+				? inflate(bytes, 1, bytes.length - 1)
+				: bytes;
+		return deserialize(serialized);
+	}
+
+	private static byte[] serialize(final Object thing) {
 		try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			 final ObjectOutputStream oos = new ObjectOutputStream(baos)) {
 			oos.writeObject(thing);
@@ -125,15 +182,54 @@ public class ValkeyCacheService implements MemcacheService {
 		}
 	}
 
-	private static Object fromCacheBytes(final byte[] bytes) {
-		if (bytes == null || Arrays.equals(bytes, NULL_VALUE)) {
-			return null;
-		}
-		try (final ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+	private static Object deserialize(final byte[] serialized) {
+		try (final ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
 			 final ObjectInputStream ois = new ObjectInputStream(bais)) {
 			return ois.readObject();
 		} catch (final IOException | ClassNotFoundException e) {
 			throw new RuntimeException("Failed to deserialize cache value", e);
+		}
+	}
+
+	/** Deflates {@code data}, prefixing the {@link #FORMAT_DEFLATE} marker so reads can spot the encoding. */
+	private static byte[] deflate(final byte[] data) {
+		final Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION);
+		try {
+			deflater.setInput(data);
+			deflater.finish();
+			// Compressed output is normally well under the input size; the marker byte rides along in front.
+			final ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.max(64, data.length / 3));
+			baos.write(FORMAT_DEFLATE);
+			final byte[] buffer = new byte[8192];
+			while (!deflater.finished()) {
+				final int n = deflater.deflate(buffer);
+				baos.write(buffer, 0, n);
+			}
+			return baos.toByteArray();
+		} finally {
+			deflater.end();
+		}
+	}
+
+	/** Inflates the {@code length} bytes at {@code offset} (the payload after the {@link #FORMAT_DEFLATE} marker). */
+	private static byte[] inflate(final byte[] data, final int offset, final int length) {
+		final Inflater inflater = new Inflater();
+		try {
+			inflater.setInput(data, offset, length);
+			final ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.max(64, length * 3));
+			final byte[] buffer = new byte[8192];
+			while (!inflater.finished()) {
+				final int n = inflater.inflate(buffer);
+				if (n == 0 && (inflater.needsInput() || inflater.needsDictionary())) {
+					throw new IllegalStateException("Corrupt or truncated compressed cache value");
+				}
+				baos.write(buffer, 0, n);
+			}
+			return baos.toByteArray();
+		} catch (final DataFormatException e) {
+			throw new RuntimeException("Failed to decompress cache value", e);
+		} finally {
+			inflater.end();
 		}
 	}
 

--- a/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCacheServiceTests.java
+++ b/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCacheServiceTests.java
@@ -17,7 +17,10 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -358,6 +361,41 @@ class ValkeyCacheServiceTests {
 		}
 	}
 
+	@Test
+	void injectedFactoryRemapsClassNamesOnRead() {
+		// Simulates the split you get when one process writes with shaded (relocated) dependencies and
+		// another reads with un-relocated ones: a value serialized under one class name is read back by a
+		// process that only has the class under a different name, which otherwise surfaces as a
+		// ClassNotFoundException. A ValkeyCacheService built with a custom ObjectInputStreamFactory that
+		// swaps the class descriptor must decode it. The swap is done in readClassDescriptor(), not
+		// resolveClass(): since JDK 17 the latter rejects a class whose name differs from the stream
+		// descriptor with InvalidClassException.
+		final String writtenName = Alpha.class.getName();
+		final MemcacheService remapping = new ValkeyCacheService(client, in -> new ObjectInputStream(in) {
+			@Override
+			protected ObjectStreamClass readClassDescriptor() throws IOException, ClassNotFoundException {
+				final ObjectStreamClass desc = super.readClassDescriptor();
+				return desc.getName().equals(writtenName) ? ObjectStreamClass.lookup(Beta.class) : desc;
+			}
+		});
+
+		remapping.put("k", new Alpha("payload"));
+		final Object read = remapping.get("k");
+
+		assertThat(read).isInstanceOf(Beta.class);
+		assertThat(((Beta) read).s).isEqualTo("payload");
+	}
+
+	@Test
+	void factoryConstructorRoundTripsAndAppliesDefaultTtl() throws Exception {
+		// The (client, ttl, factory) constructor honors both the TTL and a plain-delegating factory.
+		final MemcacheService withFactory =
+				new ValkeyCacheService(client, 100, ObjectInputStream::new);
+		withFactory.put("k", new Alpha("v"));
+		assertThat(((Alpha) withFactory.get("k")).s).isEqualTo("v");
+		assertThat(ttlOf("k")).isGreaterThan(0L);
+	}
+
 	private static byte[] rawBytes(final String key) throws Exception {
 		final GlideString value = client.get(GlideString.gs(key.getBytes(StandardCharsets.UTF_8))).get();
 		return value == null ? null : value.getBytes();
@@ -379,6 +417,29 @@ class ValkeyCacheServiceTests {
 		final char[] chars = new char[n];
 		Arrays.fill(chars, c);
 		return new String(chars);
+	}
+
+	/**
+	 * {@link Alpha} and {@link Beta} share an identical serial layout and {@code serialVersionUID}, so a
+	 * stream written as {@code Alpha} deserializes into {@code Beta} once {@code resolveClass} maps the
+	 * name — the same compatibility the shaded/un-relocated Guava class pairs rely on.
+	 */
+	private static class Alpha implements Serializable {
+		private static final long serialVersionUID = 99L;
+		private final String s;
+
+		Alpha(final String s) {
+			this.s = s;
+		}
+	}
+
+	private static class Beta implements Serializable {
+		private static final long serialVersionUID = 99L;
+		private final String s;
+
+		Beta(final String s) {
+			this.s = s;
+		}
 	}
 
 	private static class Sample implements Serializable {

--- a/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCacheServiceTests.java
+++ b/src/test/java/com/googlecode/objectify/test/valkey/ValkeyCacheServiceTests.java
@@ -6,6 +6,7 @@ import com.googlecode.objectify.cache.MemcacheService.CasPut;
 import com.googlecode.objectify.cache.valkey.ValkeyCacheService;
 import com.googlecode.objectify.cache.valkey.ValkeyIdentifiableValue;
 import glide.api.GlideClient;
+import glide.api.models.GlideString;
 import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.configuration.NodeAddress;
 import org.junit.jupiter.api.AfterAll;
@@ -15,7 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -283,6 +287,98 @@ class ValkeyCacheServiceTests {
 		assertThat(wins.get()).isEqualTo(1);
 		assertThat(cache.get(key)).isInstanceOf(String.class);
 		assertThat((String) cache.get(key)).startsWith("writer-");
+	}
+
+	@Test
+	void largeValueRoundTripsThroughCompression() throws Exception {
+		final String big = repeat('x', 200_000);
+		cache.put("big", big);
+
+		// Round-trips intact...
+		assertThat(cache.get("big")).isEqualTo(big);
+
+		// ...and was actually stored compressed: the deflate marker leads, and the stored form is far
+		// smaller than the raw serialization.
+		final byte[] stored = rawBytes("big");
+		assertThat(stored[0] & 0xFF).isEqualTo(0x01);
+		assertThat(stored.length).isLessThan(javaSerialize(big).length);
+	}
+
+	@Test
+	void smallValueIsStoredUncompressed() throws Exception {
+		cache.put("small", new Sample("hello", 42));
+
+		// Below the threshold we skip compression, so the stored bytes are a bare Java serialization
+		// (stream magic 0xAC), not a compressed payload.
+		final byte[] stored = rawBytes("small");
+		assertThat(stored[0] & 0xFF).isEqualTo(0xAC);
+	}
+
+	@Test
+	void midSizeValueAboveThresholdIsCompressed() throws Exception {
+		// ~4 KB serialized: below the old 16 KB memcache cutoff but above the current 2 KB threshold,
+		// so it must now be compressed. Guards the lowered threshold against silently regressing to 16 KB.
+		final String mid = repeat('z', 4_000);
+		assertThat(javaSerialize(mid).length).isGreaterThan(ValkeyCacheService.COMPRESSION_THRESHOLD_BYTES);
+		cache.put("mid", mid);
+
+		assertThat(cache.get("mid")).isEqualTo(mid);
+		final byte[] stored = rawBytes("mid");
+		assertThat(stored[0] & 0xFF).isEqualTo(0x01);
+	}
+
+	@Test
+	void readsLegacyUncompressedValueWrittenBeforeCompression() throws Exception {
+		// An entry written by the pre-compression code is a raw Java serialization with no marker byte.
+		final Sample value = new Sample("legacy", 7);
+		writeRaw("legacy", javaSerialize(value));
+		assertThat(cache.get("legacy")).isEqualTo(value);
+	}
+
+	@Test
+	void readsLegacyLargeUncompressedValue() throws Exception {
+		// A large entry written before compression existed is stored uncompressed; the read path must not
+		// assume "large implies compressed", so this must deserialize directly rather than try to inflate.
+		final String big = repeat('y', 200_000);
+		writeRaw("legacy-big", javaSerialize(big));
+		assertThat(cache.get("legacy-big")).isEqualTo(big);
+	}
+
+	@Test
+	void readsEmptyStoredValueAsCorruptRatherThanIndexError() throws Exception {
+		// A zero-length value can't come from our own writes, but an external writer could leave one.
+		// It must not trip an ArrayIndexOutOfBoundsException on the format-byte check; it falls through
+		// to deserialization, which wraps the failure descriptively.
+		writeRaw("empty", new byte[0]);
+		try {
+			cache.get("empty");
+			throw new AssertionError("expected a wrapped deserialization failure");
+		} catch (final RuntimeException expected) {
+			assertThat(expected).isNotInstanceOf(ArrayIndexOutOfBoundsException.class);
+		}
+	}
+
+	private static byte[] rawBytes(final String key) throws Exception {
+		final GlideString value = client.get(GlideString.gs(key.getBytes(StandardCharsets.UTF_8))).get();
+		return value == null ? null : value.getBytes();
+	}
+
+	private static void writeRaw(final String key, final byte[] bytes) throws Exception {
+		client.set(GlideString.gs(key.getBytes(StandardCharsets.UTF_8)), GlideString.gs(bytes)).get();
+	}
+
+	private static byte[] javaSerialize(final Object thing) throws Exception {
+		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try (final ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+			oos.writeObject(thing);
+		}
+		return baos.toByteArray();
+	}
+
+	private static String repeat(final char c, final int n) {
+		final char[] chars = new char[n];
+		Arrays.fill(chars, c);
+		return new String(chars);
 	}
 
 	private static class Sample implements Serializable {


### PR DESCRIPTION
Two more `ValkeyCacheService` changes on top of #528, both running in production.

**1. Compress large values (`43ca27b2`).** Serialized values at or above 2 KB are Deflate-compressed before storage, behind a `0x01` marker byte. The three possible leading bytes can't collide — `0x00` is the null sentinel, `0xAC` opens every Java serialization stream, `0x01` marks a compressed payload — so the read path identifies the encoding from the first byte and accepts either form. Entries written before this change, and anything under the threshold, still deserialize as plain serializations, which makes it safe to roll out and to roll back.

The 2 KB threshold is deliberately lower than the ~16 KB spymemcached's default transcoder used. Memcache evicts transparently under memory pressure; a Valkey instance is bounded by `maxmemory`, so compressing more of the keyspace is worth a little CPU on mid-size values.

**2. Pluggable `ObjectInputStream` (`e58d41de`).** The read path hardcoded `new ObjectInputStream(...)`, which resolves classes by their exact stored name. That breaks when the writing and reading processes disagree about class names — most commonly when one was built with its dependencies relocated by a shading step, so the same class is stored as `shaded.com.example.Foo` in one and `com.example.Foo` in the other, and the reader gets a `ClassNotFoundException`. This adds an optional `ObjectInputStreamFactory` so a caller can supply a subclass that remaps names, letting processes with different relocation schemes share one cache.

The default is unchanged and the existing constructors delegate to it, so it's purely additive. No remapping implementation is included — what a name maps to is deployment-specific. The test supplies one to prove the hook works; note it swaps in `readClassDescriptor()` rather than `resolveClass()`, because JDK 17+ rejects a `resolveClass()` result whose name differs from the stream descriptor with `InvalidClassException`.

**Testing.** 8 new tests: compression round-trips above and below the threshold, a mid-size value between the old and new thresholds, reads of legacy uncompressed entries (including large ones), a zero-length value left by an external writer surfacing as a wrapped failure rather than an index error, and both new constructors. All 33 tests under `src/test/java/com/googlecode/objectify/test/valkey` pass.

**One design question worth raising:** this takes `ValkeyCacheService` to four public constructors, and `COMPRESSION_THRESHOLD_BYTES` is a public constant rather than something a caller can tune. I kept it matching what's deployed rather than redesigning, but if you'd want the threshold configurable too, constructor overloads stop scaling well and it probably wants a small builder instead. Happy to reshape it either way.